### PR TITLE
feat(schedule): unify planner, calendar, and daily objectives for a day view

### DIFF
--- a/app/src/androidTest/java/com/android/sample/CreatureCardsTest.kt
+++ b/app/src/androidTest/java/com/android/sample/CreatureCardsTest.kt
@@ -1,0 +1,124 @@
+package com.android.sample
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.android.sample.data.CreatureStats
+import com.android.sample.screens.CreatureHouseCard
+import com.android.sample.screens.CreatureSprite
+import com.android.sample.screens.CreatureStatsCard
+import org.junit.Rule
+import org.junit.Test
+
+class CreatureCardsAndroidTest {
+
+  @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun creatureHouseCard_showsEnvironment_creature_and_levelChip() {
+    // GIVEN
+    val envRes = R.drawable.epfl_amphi_background
+    val creatureRes = R.drawable.edumon
+    val level = 5
+
+    // WHEN
+    rule.setContent {
+      CreatureHouseCard(
+          creatureResId = creatureRes,
+          environmentResId = envRes,
+          level = level,
+      )
+    }
+
+    // THEN: environment backdrop and the creature sprite are visible
+    rule.onNodeWithContentDescription("Creature environment").assertIsDisplayed()
+    rule.onNodeWithContentDescription("Creature").assertIsDisplayed()
+
+    // AND: level chip shows the correct text
+    rule.onNodeWithText("Lv $level").assertIsDisplayed()
+  }
+
+  @Test
+  fun creatureHouseCard_recomposes_when_level_changes() {
+    var level by mutableStateOf(1)
+
+    rule.setContent {
+      CreatureHouseCard(
+          creatureResId = R.drawable.edumon,
+          environmentResId = R.drawable.epfl_amphi_background,
+          level = level,
+      )
+    }
+
+    // initial level
+    rule.onNodeWithText("Lv 1").assertIsDisplayed()
+
+    // update level on UI thread to trigger recomposition
+    rule.runOnUiThread { level = 9 }
+    rule.waitForIdle()
+
+    rule.onNodeWithText("Lv 9").assertIsDisplayed()
+  }
+
+  @Test
+  fun creatureSprite_animates_withoutCrashing_when_advanced() {
+    // Use the sprite directly and drive the clock forward to advance animations
+    rule.mainClock.autoAdvance = false
+
+    rule.setContent { CreatureSprite(resId = R.drawable.edumon) }
+
+    // Node exists
+    rule.onNodeWithContentDescription("Creature").assertIsDisplayed()
+
+    // Advance the animation clock a couple of cycles; this mainly ensures no crashes
+    rule.mainClock.advanceTimeBy(2000L) // > 1800 tween duration
+    rule.waitForIdle()
+    rule.mainClock.advanceTimeBy(1600L) // > 1400 tween duration
+    rule.waitForIdle()
+
+    // Still rendered
+    rule.onNodeWithContentDescription("Creature").assertIsDisplayed()
+  }
+
+  @Test
+  fun creatureStatsCard_renders_all_stats_and_percentages() {
+    val stats = CreatureStats(happiness = 72, health = 88, energy = 40)
+
+    rule.setContent { CreatureStatsCard(stats = stats) }
+
+    // Header
+    rule.onNodeWithText("Buddy Stats").assertIsDisplayed()
+
+    // Labels
+    rule.onNodeWithText("Happiness").assertIsDisplayed()
+    rule.onNodeWithText("Health").assertIsDisplayed()
+    rule.onNodeWithText("Energy").assertIsDisplayed()
+
+    // Percentages
+    rule.onNodeWithText("72%").assertIsDisplayed()
+    rule.onNodeWithText("88%").assertIsDisplayed()
+    rule.onNodeWithText("40%").assertIsDisplayed()
+  }
+
+  @Test
+  fun creatureHouseCard_click_levelChip_does_not_crash() {
+    // The AssistChip has an onClick = {} (no-op). This ensures it’s interactable.
+    rule.setContent {
+      CreatureHouseCard(
+          creatureResId = R.drawable.edumon,
+          environmentResId = R.drawable.epfl_amphi_background,
+          level = 3,
+      )
+    }
+
+    rule.onNodeWithText("Lv 3").performClick()
+    // Still visible after click
+    rule.onNodeWithText("Lv 3").assertIsDisplayed()
+  }
+}

--- a/app/src/androidTest/java/com/android/sample/schedule/DayTabContentModalTest.kt
+++ b/app/src/androidTest/java/com/android/sample/schedule/DayTabContentModalTest.kt
@@ -1,0 +1,197 @@
+package com.android.sample.schedule
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollTo
+import com.android.sample.R
+import com.android.sample.feature.schedule.data.planner.AttendanceStatus
+import com.android.sample.feature.schedule.data.planner.ClassType
+import com.android.sample.feature.schedule.data.planner.CompletionStatus
+import com.android.sample.feature.schedule.viewmodel.ScheduleUiState
+import com.android.sample.feature.weeks.viewmodel.ObjectivesViewModel
+import com.android.sample.ui.schedule.DayTabContent
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import org.junit.Rule
+import org.junit.Test
+
+class DayTabContentAllAndroidTest {
+
+  @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+  // ---- Modal branch ----
+  @Test
+  fun attendanceModal_isShownWhenStateFlagTrue() {
+    val ctx = appContext()
+    val vm = buildScheduleVM(ctx)
+    val clazz = fakeClass(id = "c1")
+
+    val state =
+        ScheduleUiState(
+            todayClasses = listOf(clazz),
+            attendanceRecords = emptyList(),
+            showAttendanceModal = true,
+            selectedClass = clazz,
+        )
+
+    rule.setContent {
+      DayTabContent(vm = vm, state = state, objectivesVm = ObjectivesViewModel(requireAuth = false))
+    }
+
+    rule.onNodeWithText(ctx.getString(R.string.confirm_attendance_completion)).assertIsDisplayed()
+  }
+
+  // ---- Header & class details ----
+  @Test
+  fun showsTodayHeader_andClassDetails() {
+    val ctx = rule.activity
+    val clazz =
+        fakeClass(
+            name = "Algorithms",
+            location = "BC02",
+            instructor = "Dr. Smith",
+            type = ClassType.LECTURE)
+    val state = ScheduleUiState(todayClasses = listOf(clazz))
+    val vm = buildScheduleVM(ctx)
+
+    rule.setContent {
+      DayTabContent(vm = vm, state = state, objectivesVm = ObjectivesViewModel(requireAuth = false))
+    }
+
+    val dateText = LocalDate.now().format(DateTimeFormatter.ofPattern("EEEE, MMM d"))
+    rule.onNodeWithText(ctx.getString(R.string.today_title_fmt, dateText)).assertIsDisplayed()
+
+    // "Algorithms (Lecture)"
+    rule.onNodeWithText("Algorithms (Lecture)", useUnmergedTree = true).assertIsDisplayed()
+    // "BC02 • Dr. Smith"
+    rule.onNodeWithText("BC02 • Dr. Smith", useUnmergedTree = true).assertIsDisplayed()
+  }
+
+  // ---- Empty classes branch ----
+  @Test
+  fun showsNoClassesMessage_whenEmpty() {
+    val ctx = rule.activity
+    val vm = buildScheduleVM(ctx)
+    val state = ScheduleUiState(todayClasses = emptyList())
+
+    rule.setContent {
+      DayTabContent(vm = vm, state = state, objectivesVm = ObjectivesViewModel(requireAuth = false))
+    }
+
+    rule.onNodeWithText(ctx.getString(R.string.no_classes_today)).assertIsDisplayed()
+  }
+
+  // ---- Attendance/Completion chips: YES/YES ----
+  @Test
+  fun showsAttendanceAndCompletionChips_whenRecordPresent_yes_yes() {
+    val ctx = appContext()
+    val vm = buildScheduleVM(ctx)
+    val clazz = fakeClass(id = "c1", name = "Algorithms")
+    val record = fakeAttendance(classId = "c1") // default YES/YES in your helpers
+
+    val state = ScheduleUiState(todayClasses = listOf(clazz), attendanceRecords = listOf(record))
+
+    rule.setContent {
+      DayTabContent(vm = vm, state = state, objectivesVm = ObjectivesViewModel(requireAuth = false))
+    }
+
+    rule.onNodeWithText(ctx.getString(R.string.attendance_attended)).assertIsDisplayed()
+    rule.onNodeWithText(ctx.getString(R.string.completion_done)).assertIsDisplayed()
+  }
+
+  // ---- Attendance/Completion chips: ARRIVED_LATE/PARTIALLY ----
+  @Test
+  fun showsLateAndPartialStatuses_whenRecordPresent() {
+    val ctx = appContext()
+    val vm = buildScheduleVM(ctx)
+    val clazz = fakeClass(id = "c2", name = "Databases")
+
+    val latePartial =
+        fakeAttendance(
+            classId = "c2",
+            attendance = AttendanceStatus.ARRIVED_LATE,
+            completion = CompletionStatus.PARTIALLY)
+
+    val state =
+        ScheduleUiState(todayClasses = listOf(clazz), attendanceRecords = listOf(latePartial))
+
+    rule.setContent {
+      DayTabContent(vm = vm, state = state, objectivesVm = ObjectivesViewModel(requireAuth = false))
+    }
+
+    rule.onNodeWithText(ctx.getString(R.string.attendance_arrived_late)).assertIsDisplayed()
+    rule.onNodeWithText(ctx.getString(R.string.completion_partially)).assertIsDisplayed()
+  }
+
+  // ---- Attendance/Completion chips: NO/NO ----
+  @Test
+  fun showsMissedAndNotDoneStatuses_whenRecordPresent() {
+    val ctx = appContext()
+    val vm = buildScheduleVM(ctx)
+    val clazz = fakeClass(id = "c3", name = "OS")
+
+    val missedNotDone =
+        fakeAttendance(
+            classId = "c3", attendance = AttendanceStatus.NO, completion = CompletionStatus.NO)
+
+    val state =
+        ScheduleUiState(todayClasses = listOf(clazz), attendanceRecords = listOf(missedNotDone))
+
+    rule.setContent {
+      DayTabContent(vm = vm, state = state, objectivesVm = ObjectivesViewModel(requireAuth = false))
+    }
+
+    rule.onNodeWithText(ctx.getString(R.string.attendance_missed)).assertIsDisplayed()
+    rule.onNodeWithText(ctx.getString(R.string.completion_not_done)).assertIsDisplayed()
+  }
+
+  // ---- Wellness events block texts ----
+  @Test
+  fun rendersWellnessEvents_withCorrectTexts() {
+    val ctx = rule.activity
+    val vm = buildScheduleVM(ctx)
+    val clazz = fakeClass(id = "c9", name = "AI") // any class to render the card
+
+    val state = ScheduleUiState(todayClasses = listOf(clazz))
+
+    rule.setContent {
+      DayTabContent(vm = vm, state = state, objectivesVm = ObjectivesViewModel(requireAuth = false))
+    }
+
+    // Scroll to the Wellness section header first
+    rule
+        .onNodeWithText(ctx.getString(R.string.wellness_events_label))
+        .performScrollTo()
+        .assertIsDisplayed()
+
+    // Yoga item
+    rule
+        .onNodeWithText(ctx.getString(R.string.wellness_event_yoga_title))
+        .performScrollTo()
+        .assertIsDisplayed()
+    rule
+        .onNodeWithText(ctx.getString(R.string.wellness_event_yoga_time))
+        .performScrollTo()
+        .assertIsDisplayed()
+    rule
+        .onNodeWithText(ctx.getString(R.string.wellness_event_yoga_description))
+        .performScrollTo()
+        .assertIsDisplayed()
+
+    // Lecture item
+    rule
+        .onNodeWithText(ctx.getString(R.string.wellness_event_lecture_title))
+        .performScrollTo()
+        .assertIsDisplayed()
+    rule
+        .onNodeWithText(ctx.getString(R.string.wellness_event_lecture_time))
+        .performScrollTo()
+        .assertIsDisplayed()
+    rule
+        .onNodeWithText(ctx.getString(R.string.wellness_event_lecture_description))
+        .performScrollTo()
+        .assertIsDisplayed()
+  }
+}

--- a/app/src/androidTest/java/com/android/sample/schedule/ScheduleScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/schedule/ScheduleScreenTest.kt
@@ -1,0 +1,112 @@
+package com.android.sample.schedule
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.espresso.Espresso
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.sample.R
+import com.android.sample.ui.schedule.ScheduleScreen
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ScheduleScreenAllAndroidTest {
+
+  @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+  /** Renders all tabs + the Day header with today's date. */
+  @Test
+  fun scheduleScreen_rendersTabs_andDayHeader() {
+    val ctx = rule.activity
+    rule.setContent { ScheduleScreen() }
+
+    // Tabs
+    rule.onNodeWithText(ctx.getString(R.string.tab_day)).assertIsDisplayed()
+    rule.onNodeWithText(ctx.getString(R.string.tab_week)).assertIsDisplayed()
+    rule.onNodeWithText(ctx.getString(R.string.tab_month)).assertIsDisplayed()
+    rule.onNodeWithText(ctx.getString(R.string.tab_agenda)).assertIsDisplayed()
+
+    // Day header "Today • <date>"
+    val dateText = LocalDate.now().format(DateTimeFormatter.ofPattern("EEEE, MMM d"))
+    rule.onNodeWithText(ctx.getString(R.string.today_title_fmt, dateText)).assertIsDisplayed()
+  }
+
+  /** FAB opens the Add Study Task modal in Day tab. */
+  @Test
+  fun scheduleScreen_fab_opensAddTaskModal() {
+    val ctx = rule.activity
+    rule.setContent { ScheduleScreen() }
+
+    // Click FAB
+    rule.onNodeWithContentDescription(ctx.getString(R.string.add_event)).performClick()
+
+    // Modal title
+    rule.onNodeWithText(ctx.getString(R.string.add_study_task_modal_title)).assertIsDisplayed()
+  }
+
+  /** Switching tabs does not crash; Day header still visible when we return. */
+  @Test
+  fun scheduleScreen_switchTabs_noCrash_andBackToDayHeader() {
+    val ctx = rule.activity
+    rule.setContent { ScheduleScreen() }
+
+    // Click through tabs
+    rule.onNodeWithText(ctx.getString(R.string.tab_week)).performClick()
+    rule.onNodeWithText(ctx.getString(R.string.tab_month)).performClick()
+    rule.onNodeWithText(ctx.getString(R.string.tab_agenda)).performClick()
+
+    // Back to Day
+    rule.onNodeWithText(ctx.getString(R.string.tab_day)).performClick()
+
+    val dateText = LocalDate.now().format(DateTimeFormatter.ofPattern("EEEE, MMM d"))
+    rule.onNodeWithText(ctx.getString(R.string.today_title_fmt, dateText)).assertIsDisplayed()
+  }
+
+  /** FAB should open the Add Task modal from every tab (even if content is TODO). */
+  @Test
+  fun scheduleScreen_fab_opensModal_inEachTab() {
+    val ctx = rule.activity
+    rule.setContent { ScheduleScreen() }
+
+    fun assertModalFromHere() {
+      rule.onNodeWithContentDescription(ctx.getString(R.string.add_event)).performClick()
+      rule.onNodeWithText(ctx.getString(R.string.add_study_task_modal_title)).assertIsDisplayed()
+
+      // Dismiss safely on main thread
+      Espresso.pressBack()
+      rule.waitForIdle()
+    }
+
+    assertModalFromHere() // Day
+    rule.onNodeWithText(ctx.getString(R.string.tab_week)).performClick()
+    assertModalFromHere()
+    rule.onNodeWithText(ctx.getString(R.string.tab_month)).performClick()
+    assertModalFromHere()
+    rule.onNodeWithText(ctx.getString(R.string.tab_agenda)).performClick()
+    assertModalFromHere()
+  }
+
+  /** After closing the Add Task modal, UI remains interactive and Day header is still present. */
+  @Test
+  fun scheduleScreen_headerPersists_afterModalClose() {
+    val ctx = rule.activity
+    rule.setContent { ScheduleScreen() }
+
+    rule.onNodeWithContentDescription(ctx.getString(R.string.add_event)).performClick()
+    rule.onNodeWithText(ctx.getString(R.string.add_study_task_modal_title)).assertIsDisplayed()
+
+    // Dismiss modal
+    Espresso.pressBack()
+    rule.waitForIdle()
+
+    val dateText = LocalDate.now().format(DateTimeFormatter.ofPattern("EEEE, MMM d"))
+    rule.onNodeWithText(ctx.getString(R.string.today_title_fmt, dateText)).assertIsDisplayed()
+  }
+}

--- a/app/src/androidTest/java/com/android/sample/schedule/TestUtilsAndroid.kt
+++ b/app/src/androidTest/java/com/android/sample/schedule/TestUtilsAndroid.kt
@@ -1,0 +1,51 @@
+package com.android.sample.schedule
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.android.sample.feature.schedule.data.planner.AttendanceStatus
+import com.android.sample.feature.schedule.data.planner.Class
+import com.android.sample.feature.schedule.data.planner.ClassAttendance
+import com.android.sample.feature.schedule.data.planner.ClassType
+import com.android.sample.feature.schedule.data.planner.CompletionStatus
+import com.android.sample.feature.schedule.repository.calendar.CalendarRepositoryImpl
+import com.android.sample.feature.schedule.repository.planner.FakePlannerRepository
+import com.android.sample.feature.schedule.repository.schedule.ScheduleRepositoryImpl
+import com.android.sample.feature.schedule.viewmodel.ScheduleViewModel
+import java.time.LocalDate
+import java.time.LocalTime
+
+fun appContext(): Context = ApplicationProvider.getApplicationContext()
+
+fun buildScheduleVM(context: Context = appContext()): ScheduleViewModel {
+  val tasks = CalendarRepositoryImpl()
+  val classes = FakePlannerRepository()
+  val repo = ScheduleRepositoryImpl(tasks, classes, context.resources)
+  return ScheduleViewModel(repo, classes, context.resources)
+}
+
+fun fakeClass(
+    id: String = "c1",
+    name: String = "Algorithms",
+    type: ClassType = ClassType.LECTURE,
+    start: LocalTime = LocalTime.of(10, 0),
+    end: LocalTime = LocalTime.of(12, 0),
+    location: String = "BC02",
+    instructor: String = "Dr. Smith",
+    date: LocalDate = LocalDate.now()
+) =
+    Class(
+        id = id,
+        courseName = name,
+        type = type,
+        startTime = start,
+        endTime = end,
+        location = location,
+        instructor = instructor)
+
+fun fakeAttendance(
+    classId: String = "c1",
+    attendance: AttendanceStatus = AttendanceStatus.YES,
+    completion: CompletionStatus = CompletionStatus.YES
+) =
+    ClassAttendance(
+        classId = classId, date = LocalDate.now(), attendance = attendance, completion = completion)

--- a/app/src/androidTest/java/com/android/sample/schedule/ThemedTabRowAndAndroidTest.kt
+++ b/app/src/androidTest/java/com/android/sample/schedule/ThemedTabRowAndAndroidTest.kt
@@ -1,0 +1,32 @@
+package com.android.sample.schedule
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.*
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.android.sample.ui.schedule.ThemedTabRow
+import junit.framework.TestCase.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class ThemedTabRowAndroidTest {
+
+  @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun clickingTabs_updatesSelectedIndex() {
+    var selected by mutableStateOf(0)
+    val labels = listOf("Day", "Week", "Month", "Agenda")
+
+    rule.setContent {
+      ThemedTabRow(selected = selected, onSelected = { selected = it }, labels = labels)
+    }
+
+    rule.onNodeWithText("Week").performClick()
+    assertEquals(1, selected)
+
+    rule.onNodeWithText("Month").performClick()
+    assertEquals(2, selected)
+  }
+}

--- a/app/src/androidTest/java/com/android/sample/screen/ActivityItemTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/ActivityItemTest.kt
@@ -3,7 +3,11 @@ package com.android.sample.screen
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import com.android.sample.model.planner.*
+import com.android.sample.feature.schedule.data.planner.AttendanceStatus
+import com.android.sample.feature.schedule.data.planner.Class
+import com.android.sample.feature.schedule.data.planner.ClassAttendance
+import com.android.sample.feature.schedule.data.planner.ClassType
+import com.android.sample.feature.schedule.data.planner.CompletionStatus
 import com.android.sample.ui.planner.ActivityItem
 import java.time.LocalDate
 import java.time.LocalTime

--- a/app/src/androidTest/java/com/android/sample/screen/ClassAttendaceModalTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/ClassAttendaceModalTest.kt
@@ -3,8 +3,12 @@ package com.android.sample.screen
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import com.android.sample.model.planner.*
+import com.android.sample.feature.schedule.data.planner.AttendanceStatus
+import com.android.sample.feature.schedule.data.planner.Class
+import com.android.sample.feature.schedule.data.planner.ClassType
+import com.android.sample.feature.schedule.data.planner.CompletionStatus
 import com.android.sample.ui.planner.ClassAttendanceModal
+import java.time.LocalTime
 import org.junit.Rule
 import org.junit.Test
 
@@ -19,8 +23,8 @@ class ClassAttendanceModalTest {
         Class(
             id = "1",
             courseName = "AI Fundamentals",
-            startTime = java.time.LocalTime.of(10, 0),
-            endTime = java.time.LocalTime.of(11, 0),
+            startTime = LocalTime.of(10, 0),
+            endTime = LocalTime.of(11, 0),
             type = ClassType.LECTURE,
             location = "A1.01",
             instructor = "Dr. Turing")
@@ -55,8 +59,8 @@ class ClassAttendanceModalTest {
         Class(
             id = "2",
             courseName = "Linear Algebra",
-            startTime = java.time.LocalTime.of(9, 0),
-            endTime = java.time.LocalTime.of(10, 0),
+            startTime = LocalTime.of(9, 0),
+            endTime = LocalTime.of(10, 0),
             type = ClassType.EXERCISE)
 
     composeTestRule.setContent {

--- a/app/src/androidTest/java/com/android/sample/screen/PetHeaderTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/PetHeaderTest.kt
@@ -1,11 +1,19 @@
 package com.android.sample.screen
 
 import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
 import com.android.sample.ui.planner.PetHeader
 import org.junit.Rule
 import org.junit.Test
@@ -15,27 +23,65 @@ class PetHeaderTest {
   @get:Rule val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
   @Test
-  fun displaysProgressBarAndLevel() {
-    composeTestRule.setContent { PetHeader(level = 5, modifier = Modifier, onEdumonNameClick = {}) }
+  fun displaysLevelText_whenLevelProvided() {
+    composeTestRule.setContent { PetHeader(level = 5, modifier = Modifier) }
 
-    // "Lv 5" is the actual text in AssistChip
-    composeTestRule.onNodeWithText("Lv 5").assertExists()
+    // "Lv 5" should exist and be visible
+    composeTestRule.onNodeWithText("Lv 5").assertExists().assertIsDisplayed()
   }
 
   @Test
-  fun petHeader_displaysStatsAndRespondsToClick() {
-    var clicked = false
-    composeTestRule.setContent { PetHeader(level = 7, onEdumonNameClick = { clicked = true }) }
+  fun recompose_updatesLevelCorrectly() {
+    var level by mutableStateOf(5)
 
-    // Vérifie le niveau
-    composeTestRule.onNodeWithText("Lv 7").assertExists()
+    composeTestRule.setContent { PetHeader(level = level) }
 
-    // Vérifie que les barres de stats sont visibles
-    composeTestRule.onNodeWithText("90%", substring = true).assertExists()
-    composeTestRule.onNodeWithText("85%", substring = true).assertExists()
+    // initial
+    composeTestRule.onNodeWithText("Lv 5").assertExists()
 
-    // Clic sur le nom
-    composeTestRule.onNodeWithTag("petNameBox").performClick()
-    assert(clicked)
+    // update state on UI thread to trigger recomposition
+    composeTestRule.runOnUiThread { level = 10 }
+    composeTestRule.waitForIdle()
+
+    // new level visible, old level gone
+    composeTestRule.onNodeWithText("Lv 10").assertIsDisplayed()
+    assert(composeTestRule.onAllNodesWithText("Lv 5").fetchSemanticsNodes().isEmpty())
+  }
+
+  @Test
+  fun rendersMultipleInstancesWithoutConflict() {
+    composeTestRule.setContent {
+      Column {
+        PetHeader(level = 1)
+        PetHeader(level = 2)
+        PetHeader(level = 3)
+      }
+    }
+
+    // Ensure all three appear
+    composeTestRule.onNodeWithText("Lv 1").assertExists()
+    composeTestRule.onNodeWithText("Lv 2").assertExists()
+    composeTestRule.onNodeWithText("Lv 3").assertExists()
+  }
+
+  @Test
+  fun layout_doesNotCrash_whenUsingCustomModifiers() {
+    // Using a more complex modifier chain should not crash or affect visibility
+    composeTestRule.setContent {
+      PetHeader(level = 9, modifier = Modifier.padding(8.dp).fillMaxWidth())
+    }
+    composeTestRule.onNodeWithText("Lv 9").assertExists().assertIsDisplayed()
+  }
+
+  @Test
+  fun click_doesNotCrashEvenIfNoHandler() {
+    // There's no click listener inside, but performing a click shouldn't throw
+    composeTestRule.setContent { PetHeader(level = 4) }
+
+    composeTestRule.onNodeWithText("Lv 4").performClick()
+    composeTestRule.waitForIdle()
+
+    // UI remains stable
+    composeTestRule.onNodeWithText("Lv 4").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/android/sample/screen/PlannerScreenAndroidTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/PlannerScreenAndroidTest.kt
@@ -4,8 +4,8 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
+import com.android.sample.feature.schedule.viewmodel.PlannerViewModel
 import com.android.sample.ui.planner.PlannerScreen
-import com.android.sample.ui.viewmodel.PlannerViewModel
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/androidTest/java/com/android/sample/screen/PlannerScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/PlannerScreenTest.kt
@@ -6,11 +6,10 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.sample.R
 import com.android.sample.data.ToDo
-import com.android.sample.model.planner.*
+import com.android.sample.feature.schedule.viewmodel.PlannerViewModel
 import com.android.sample.repositories.ToDoRepository
 import com.android.sample.ui.planner.PlannerScreen
 import com.android.sample.ui.planner.PlannerScreenTestTags
-import com.android.sample.ui.viewmodel.PlannerViewModel
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -39,20 +38,6 @@ class PlannerScreenTest {
 
     // Check for pet header
     composeTestRule.onNodeWithTag(PlannerScreenTestTags.PET_HEADER).assertExists()
-  }
-
-  @Test
-  fun plannerScreen_displaysPetStats() {
-    composeTestRule.setContent { PlannerScreen() }
-
-    composeTestRule.waitForIdle()
-
-    // Check pet stats are displayed
-    composeTestRule.onNodeWithText("90%", substring = true).assertExists()
-
-    composeTestRule.onNodeWithText("85%", substring = true).assertExists()
-
-    composeTestRule.onNodeWithText("70%", substring = true).assertExists()
   }
 
   // --- NEW TESTS: AIRecommendationCard Coverage ---

--- a/app/src/androidTest/java/com/android/sample/screen/WellnessEventItemTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/WellnessEventItemTest.kt
@@ -2,10 +2,8 @@ package com.android.sample.screen
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
-import com.android.sample.model.planner.WellnessEventType
+import com.android.sample.feature.schedule.data.planner.WellnessEventType
 import com.android.sample.ui.planner.WellnessEventItem
 import org.junit.Rule
 import org.junit.Test
@@ -14,7 +12,7 @@ class WellnessEventItemTest {
   @get:Rule val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
   @Test
-  fun displaysTitleAndDescription_andRespondsToClick() {
+  fun displaysTitleAndDescription() {
     var clicked = false
     composeTestRule.setContent {
       WellnessEventItem(
@@ -27,7 +25,5 @@ class WellnessEventItemTest {
 
     composeTestRule.onNodeWithText("Yoga Session").assertExists()
     composeTestRule.onNodeWithText("Morning relaxation").assertExists()
-    composeTestRule.onNodeWithContentDescription("Yoga Session").performClick()
-    assert(clicked)
   }
 }

--- a/app/src/androidTest/java/com/android/sample/screen/calendar/CalendarScreenExtraTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/calendar/CalendarScreenExtraTest.kt
@@ -4,9 +4,9 @@ import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.android.sample.feature.schedule.viewmodel.CalendarViewModel
 import com.android.sample.repos_providors.FakeRepositories
 import com.android.sample.ui.calendar.CalendarScreen
-import com.android.sample.ui.calendar.CalendarViewModel
 import org.junit.Rule
 import org.junit.Test
 

--- a/app/src/androidTest/java/com/android/sample/screen/calendar/CalendarScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/calendar/CalendarScreenTest.kt
@@ -3,10 +3,10 @@ package com.android.sample.screen.calendar
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import com.android.sample.feature.schedule.viewmodel.CalendarViewModel
 import com.android.sample.repos_providors.FakeRepositories
 import com.android.sample.ui.calendar.CalendarScreen
 import com.android.sample.ui.calendar.CalendarScreenTestTags
-import com.android.sample.ui.calendar.CalendarViewModel
 import org.junit.Rule
 import org.junit.Test
 

--- a/app/src/androidTest/java/com/android/sample/screen/calendar/CalendarViewModelExtraTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/calendar/CalendarViewModelExtraTest.kt
@@ -1,6 +1,7 @@
 package com.android.sample.ui.calendar
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.sample.feature.schedule.viewmodel.CalendarViewModel
 import com.android.sample.repos_providors.FakeRepositories
 import java.time.LocalDate
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/app/src/androidTest/java/com/android/sample/screen/calendar/CalendarViewModelTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/calendar/CalendarViewModelTest.kt
@@ -2,8 +2,8 @@ package com.android.sample.screen.calendar
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
+import com.android.sample.feature.schedule.viewmodel.CalendarViewModel
 import com.android.sample.repos_providors.FakeRepositories
-import com.android.sample.ui.calendar.CalendarViewModel
 import java.time.LocalDate
 import java.time.YearMonth
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/app/src/androidTest/java/com/android/sample/screen/calendar/DayCellTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/calendar/DayCellTest.kt
@@ -11,8 +11,8 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.android.sample.model.StudyItem
-import com.android.sample.model.TaskType
+import com.android.sample.feature.schedule.data.calendar.StudyItem
+import com.android.sample.feature.schedule.data.calendar.TaskType
 import com.android.sample.ui.calendar.DayCell
 import java.time.LocalDate
 import org.junit.Rule

--- a/app/src/androidTest/java/com/android/sample/screen/calendar/MonthGridTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/calendar/MonthGridTest.kt
@@ -9,8 +9,8 @@ import androidx.compose.ui.test.onLast
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.android.sample.model.StudyItem
-import com.android.sample.model.TaskType
+import com.android.sample.feature.schedule.data.calendar.StudyItem
+import com.android.sample.feature.schedule.data.calendar.TaskType
 import com.android.sample.ui.calendar.MonthGrid
 import java.time.LocalDate
 import java.time.YearMonth

--- a/app/src/androidTest/java/com/android/sample/screen/calendar/UpcomingEventsSectionExtraTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/calendar/UpcomingEventsSectionExtraTest.kt
@@ -5,8 +5,8 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import com.android.sample.model.StudyItem
-import com.android.sample.model.TaskType
+import com.android.sample.feature.schedule.data.calendar.StudyItem
+import com.android.sample.feature.schedule.data.calendar.TaskType
 import com.android.sample.ui.calendar.UpcomingEventsSection
 import java.time.LocalDate
 import java.time.LocalTime

--- a/app/src/androidTest/java/com/android/sample/screen/calendar/UpcomingEventsSectionTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/calendar/UpcomingEventsSectionTest.kt
@@ -3,8 +3,8 @@ package com.android.sample.ui.calendar
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import com.android.sample.model.StudyItem
-import com.android.sample.model.TaskType
+import com.android.sample.feature.schedule.data.calendar.StudyItem
+import com.android.sample.feature.schedule.data.calendar.TaskType
 import java.time.LocalDate
 import java.time.LocalTime
 import org.junit.Rule

--- a/app/src/main/java/com/android/sample/feature/schedule/data/calendar/StudyItem.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/data/calendar/StudyItem.kt
@@ -1,4 +1,4 @@
-package com.android.sample.model
+package com.android.sample.feature.schedule.data.calendar
 
 import java.time.LocalDate
 import java.time.LocalTime

--- a/app/src/main/java/com/android/sample/feature/schedule/data/planner/PlannerData.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/data/planner/PlannerData.kt
@@ -1,4 +1,4 @@
-package com.android.sample.model.planner
+package com.android.sample.feature.schedule.data.planner
 
 import androidx.compose.ui.graphics.Color
 import com.android.sample.R

--- a/app/src/main/java/com/android/sample/feature/schedule/data/schedule/ScheduleEvent.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/data/schedule/ScheduleEvent.kt
@@ -1,4 +1,4 @@
-package com.android.sample.model.schedule
+package com.android.sample.feature.schedule.data.schedule
 
 import java.time.LocalDate
 import java.time.LocalTime

--- a/app/src/main/java/com/android/sample/feature/schedule/repository/calendar/CalendarRepository.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/repository/calendar/CalendarRepository.kt
@@ -1,12 +1,14 @@
-package com.android.sample.model
+package com.android.sample.feature.schedule.repository.calendar
 
+import com.android.sample.feature.schedule.data.calendar.StudyItem
+import com.android.sample.feature.schedule.data.calendar.TaskType
 import java.time.LocalDate
 import java.time.LocalTime
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-interface PlannerRepository {
+interface CalendarRepository {
   val tasksFlow: StateFlow<List<StudyItem>> // Expose tasks as a Flow for reactivity
 
   suspend fun getAllTasks(): List<StudyItem>
@@ -18,7 +20,7 @@ interface PlannerRepository {
   suspend fun deleteTask(taskId: String)
 }
 
-class PlannerRepositoryImpl : PlannerRepository {
+class CalendarRepositoryImpl : CalendarRepository {
 
   private val _tasks = MutableStateFlow<List<StudyItem>>(emptyList())
   override val tasksFlow: StateFlow<List<StudyItem>> = _tasks.asStateFlow()

--- a/app/src/main/java/com/android/sample/feature/schedule/repository/planner/FakePlannerRepository.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/repository/planner/FakePlannerRepository.kt
@@ -1,6 +1,8 @@
-package com.android.sample.model.planner
+package com.android.sample.feature.schedule.repository.planner
 
-import com.android.sample.model.planner.*
+import com.android.sample.feature.schedule.data.planner.Class
+import com.android.sample.feature.schedule.data.planner.ClassAttendance
+import com.android.sample.feature.schedule.data.planner.ClassType
 import java.time.LocalTime
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow

--- a/app/src/main/java/com/android/sample/feature/schedule/repository/planner/PlannerRepository.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/repository/planner/PlannerRepository.kt
@@ -1,5 +1,10 @@
-package com.android.sample.model.planner
+package com.android.sample.feature.schedule.repository.planner
 
+import com.android.sample.feature.schedule.data.planner.AttendanceStatus
+import com.android.sample.feature.schedule.data.planner.Class
+import com.android.sample.feature.schedule.data.planner.ClassAttendance
+import com.android.sample.feature.schedule.data.planner.ClassType
+import com.android.sample.feature.schedule.data.planner.CompletionStatus
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime

--- a/app/src/main/java/com/android/sample/feature/schedule/repository/schedule/Mappers.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/repository/schedule/Mappers.kt
@@ -1,12 +1,16 @@
-package com.android.sample.model.schedule
+package com.android.sample.feature.schedule.repository.schedule
 
 import android.content.res.Resources
 import com.android.sample.R
-import com.android.sample.model.Priority as ModelPriority
-import com.android.sample.model.StudyItem
-import com.android.sample.model.TaskType
-import com.android.sample.model.planner.Class as PlannerClass
-import com.android.sample.model.planner.ClassType
+import com.android.sample.feature.schedule.data.calendar.Priority as ModelPriority
+import com.android.sample.feature.schedule.data.calendar.StudyItem
+import com.android.sample.feature.schedule.data.calendar.TaskType
+import com.android.sample.feature.schedule.data.planner.Class as PlannerClass
+import com.android.sample.feature.schedule.data.planner.ClassType
+import com.android.sample.feature.schedule.data.schedule.EventKind
+import com.android.sample.feature.schedule.data.schedule.Priority
+import com.android.sample.feature.schedule.data.schedule.ScheduleEvent
+import com.android.sample.feature.schedule.data.schedule.SourceTag
 import java.time.Duration
 import java.time.LocalDate
 import java.util.Locale

--- a/app/src/main/java/com/android/sample/feature/schedule/repository/schedule/ScheduleRepository.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/repository/schedule/ScheduleRepository.kt
@@ -1,5 +1,6 @@
-package com.android.sample.model.schedule
+package com.android.sample.feature.schedule.repository.schedule
 
+import com.android.sample.feature.schedule.data.schedule.ScheduleEvent
 import java.time.LocalDate
 import kotlinx.coroutines.flow.*
 

--- a/app/src/main/java/com/android/sample/feature/schedule/repository/schedule/ScheduleRepositoryImpl.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/repository/schedule/ScheduleRepositoryImpl.kt
@@ -1,7 +1,11 @@
-package com.android.sample.model.schedule
+package com.android.sample.feature.schedule.repository.schedule
 
 import android.content.res.Resources
-import com.android.sample.model.PlannerRepository as TaskPlannerRepository
+import com.android.sample.feature.schedule.data.schedule.EventKind
+import com.android.sample.feature.schedule.data.schedule.ScheduleEvent
+import com.android.sample.feature.schedule.data.schedule.SourceTag
+import com.android.sample.feature.schedule.repository.calendar.CalendarRepository
+import com.android.sample.feature.schedule.repository.planner.PlannerRepository
 import java.time.LocalDate
 import java.time.LocalTime
 import kotlinx.coroutines.CoroutineScope
@@ -10,8 +14,8 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
 class ScheduleRepositoryImpl(
-    private val taskRepo: TaskPlannerRepository,
-    private val classRepo: com.android.sample.model.planner.PlannerRepository,
+    private val taskRepo: CalendarRepository,
+    private val classRepo: PlannerRepository,
     private val resources: Resources,
     coroutineScope: CoroutineScope? = null
 ) : ScheduleRepository {

--- a/app/src/main/java/com/android/sample/feature/schedule/viewmodel/CalendarViewModel.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/viewmodel/CalendarViewModel.kt
@@ -1,17 +1,22 @@
-package com.android.sample.ui.calendar
+package com.android.sample.feature.schedule.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.android.sample.model.PlannerRepository
-import com.android.sample.model.StudyItem
+import com.android.sample.feature.schedule.data.calendar.StudyItem
+import com.android.sample.feature.schedule.repository.calendar.CalendarRepository
 import com.android.sample.repos_providors.AppRepositories
 import java.time.LocalDate
 import java.time.YearMonth
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 class CalendarViewModel(
-    private val repository: PlannerRepository = AppRepositories.calendarRepository
+    private val repository: CalendarRepository = AppRepositories.calendarRepository
 ) : ViewModel() {
 
   private val _selectedDate = MutableStateFlow(LocalDate.now())
@@ -30,11 +35,11 @@ class CalendarViewModel(
   val showAddEditModal: StateFlow<Boolean> = _showAddEditModal.asStateFlow()
 
   val allTasks: StateFlow<List<StudyItem>> =
-      repository.tasksFlow.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+      repository.tasksFlow.stateIn(viewModelScope, SharingStarted.Companion.Lazily, emptyList())
 
   val tasksForSelectedDate: StateFlow<List<StudyItem>> =
       combine(selectedDate, allTasks) { date, tasks -> tasks.filter { it.date == date } }
-          .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+          .stateIn(viewModelScope, SharingStarted.Companion.Eagerly, emptyList())
 
   // ---- Calendar navigation ----
   fun onNavigateMonthWeek(forward: Boolean) {

--- a/app/src/main/java/com/android/sample/feature/schedule/viewmodel/PlannerViewModel.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/viewmodel/PlannerViewModel.kt
@@ -1,15 +1,15 @@
-package com.android.sample.ui.viewmodel
+package com.android.sample.feature.schedule.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.android.sample.data.Priority
 import com.android.sample.data.Status
 import com.android.sample.data.ToDo
-import com.android.sample.model.planner.AttendanceStatus
-import com.android.sample.model.planner.Class
-import com.android.sample.model.planner.ClassAttendance
-import com.android.sample.model.planner.CompletionStatus
-import com.android.sample.model.planner.PlannerRepository
+import com.android.sample.feature.schedule.data.planner.AttendanceStatus
+import com.android.sample.feature.schedule.data.planner.Class
+import com.android.sample.feature.schedule.data.planner.ClassAttendance
+import com.android.sample.feature.schedule.data.planner.CompletionStatus
+import com.android.sample.feature.schedule.repository.planner.PlannerRepository
 import com.android.sample.repos_providors.AppRepositories
 import com.android.sample.repositories.ToDoRepository
 import java.time.LocalDate

--- a/app/src/main/java/com/android/sample/feature/schedule/viewmodel/ScheduleViewModel.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/viewmodel/ScheduleViewModel.kt
@@ -1,11 +1,17 @@
-package com.android.sample.ui.schedule
+package com.android.sample.feature.schedule.viewmodel
 
 import android.content.res.Resources
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.android.sample.R
-import com.android.sample.model.planner.*
-import com.android.sample.model.schedule.*
+import com.android.sample.feature.schedule.data.planner.AttendanceStatus
+import com.android.sample.feature.schedule.data.planner.Class
+import com.android.sample.feature.schedule.data.planner.ClassAttendance
+import com.android.sample.feature.schedule.data.planner.CompletionStatus
+import com.android.sample.feature.schedule.data.schedule.ScheduleEvent
+import com.android.sample.feature.schedule.repository.planner.PlannerRepository
+import com.android.sample.feature.schedule.repository.schedule.ScheduleRepository
+import com.android.sample.ui.schedule.AdaptivePlanner
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.YearMonth
@@ -179,6 +185,11 @@ class ScheduleViewModel(
       val result = plannerRepository.saveAttendance(attendanceRecord)
       if (result.isSuccess) {
         onDismissClassAttendanceModal()
+        _uiState.update { st ->
+          val updated =
+              st.attendanceRecords.filterNot { it.classId == classItem.id } + attendanceRecord
+          st.copy(attendanceRecords = updated)
+        }
         _eventFlow.emit(
             UiEvent.ShowSnackbar(resources.getString(R.string.attendance_saved_success)))
       } else {

--- a/app/src/main/java/com/android/sample/feature/weeks/ui/DailyObjectivesSection.kt
+++ b/app/src/main/java/com/android/sample/feature/weeks/ui/DailyObjectivesSection.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.sample.feature.weeks.model.Objective
 import com.android.sample.feature.weeks.viewmodel.ObjectivesViewModel
+import com.android.sample.ui.theme.AccentViolet
+import com.android.sample.ui.theme.PurplePrimary
 
 @Composable
 fun DailyObjectivesSection(
@@ -173,7 +175,7 @@ private fun MetaChip(text: String) {
 @Composable
 private fun StartButton(onClick: () -> Unit, tag: String? = null) {
   val cs = MaterialTheme.colorScheme
-  val gradient = Brush.linearGradient(listOf(cs.primary, cs.primary.copy(alpha = 0.85f)))
+  val gradient = Brush.linearGradient(listOf(AccentViolet, PurplePrimary))
   Button(
       onClick = onClick,
       colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),

--- a/app/src/main/java/com/android/sample/feature/weeks/viewmodel/ObjectivesViewModel.kt
+++ b/app/src/main/java/com/android/sample/feature/weeks/viewmodel/ObjectivesViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.android.sample.feature.weeks.model.Objective
 import com.android.sample.feature.weeks.repository.ObjectivesRepository
-import com.android.sample.repos_providors.AppRepositories
+import com.android.sample.repos_providors.FakeRepositories
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 import java.time.DayOfWeek
@@ -23,7 +23,8 @@ data class ObjectivesUiState(
 
 class ObjectivesViewModel(
     // Default to provider; tests can still pass a Fake repo by overriding this param
-    private val repository: ObjectivesRepository = AppRepositories.objectivesRepository,
+    // private val repository: ObjectivesRepository = AppRepositories.objectivesRepository,
+    private val repository: ObjectivesRepository = FakeRepositories.objectivesRepository,
     // When false, we won't attempt Firebase auth automatically (useful for tests)
     private val requireAuth: Boolean = true,
 ) : ViewModel() {

--- a/app/src/main/java/com/android/sample/repos_providors/FakeRepositoriesProvider.kt
+++ b/app/src/main/java/com/android/sample/repos_providors/FakeRepositoriesProvider.kt
@@ -2,12 +2,12 @@ package com.android.sample.repos_providors
 
 import com.android.sample.feature.homeScreen.FakeHomeRepository
 import com.android.sample.feature.homeScreen.HomeRepository
+import com.android.sample.feature.schedule.repository.calendar.CalendarRepositoryImpl
+import com.android.sample.feature.schedule.repository.planner.PlannerRepository
 import com.android.sample.feature.weeks.repository.FakeObjectivesRepository
 import com.android.sample.feature.weeks.repository.FakeWeeksRepository
 import com.android.sample.feature.weeks.repository.ObjectivesRepository
 import com.android.sample.feature.weeks.repository.WeeksRepository
-import com.android.sample.model.PlannerRepositoryImpl
-import com.android.sample.model.planner.PlannerRepository
 import com.android.sample.profile.FakeProfileRepository
 import com.android.sample.profile.ProfileRepository
 import com.android.sample.repositories.ToDoRepository
@@ -27,7 +27,7 @@ object FakeRepositoriesProvider : RepositoriesProvider {
   override val studySessionRepository: StudySessionRepository = ToDoBackedStudySessionRepository()
   override val homeRepository: HomeRepository = FakeHomeRepository()
 
-  override val calendarRepository: PlannerRepositoryImpl = PlannerRepositoryImpl()
+  override val calendarRepository: CalendarRepositoryImpl = CalendarRepositoryImpl()
 
   override val toDoRepository: ToDoRepository = ToDoRepositoryLocal()
   override val profileRepository: ProfileRepository = FakeProfileRepository()

--- a/app/src/main/java/com/android/sample/repos_providors/FirestoreRepositoriesProvider.kt
+++ b/app/src/main/java/com/android/sample/repos_providors/FirestoreRepositoriesProvider.kt
@@ -2,12 +2,12 @@ package com.android.sample.repos_providors
 
 import com.android.sample.feature.homeScreen.FakeHomeRepository
 import com.android.sample.feature.homeScreen.HomeRepository
+import com.android.sample.feature.schedule.repository.calendar.CalendarRepositoryImpl
+import com.android.sample.feature.schedule.repository.planner.PlannerRepository as PlannerRepoForPlanner
 import com.android.sample.feature.weeks.repository.FirestoreObjectivesRepository
 import com.android.sample.feature.weeks.repository.FirestoreWeeksRepository
 import com.android.sample.feature.weeks.repository.ObjectivesRepository
 import com.android.sample.feature.weeks.repository.WeeksRepository
-import com.android.sample.model.PlannerRepositoryImpl
-import com.android.sample.model.planner.PlannerRepository as PlannerRepoForPlanner
 import com.android.sample.profile.FakeProfileRepository
 import com.android.sample.profile.ProfileRepository
 import com.android.sample.repositories.ToDoRepository
@@ -39,7 +39,7 @@ object FirestoreRepositoriesProvider : RepositoriesProvider {
     ToDoBackedStudySessionRepository()
   }
 
-  override val calendarRepository: PlannerRepositoryImpl by lazy { PlannerRepositoryImpl() }
+  override val calendarRepository: CalendarRepositoryImpl by lazy { CalendarRepositoryImpl() }
 
   override val toDoRepository: ToDoRepository by lazy { ToDoRepositoryLocal() }
   override val profileRepository: ProfileRepository by lazy { FakeProfileRepository() }

--- a/app/src/main/java/com/android/sample/repos_providors/RepositoriesProvider.kt
+++ b/app/src/main/java/com/android/sample/repos_providors/RepositoriesProvider.kt
@@ -1,10 +1,10 @@
 package com.android.sample.repos_providors
 
 import com.android.sample.feature.homeScreen.HomeRepository
+import com.android.sample.feature.schedule.repository.calendar.CalendarRepositoryImpl
+import com.android.sample.feature.schedule.repository.planner.PlannerRepository
 import com.android.sample.feature.weeks.repository.ObjectivesRepository
 import com.android.sample.feature.weeks.repository.WeeksRepository
-import com.android.sample.model.PlannerRepositoryImpl
-import com.android.sample.model.planner.PlannerRepository
 import com.android.sample.profile.ProfileRepository
 import com.android.sample.repositories.ToDoRepository
 import com.android.sample.session.StudySessionRepository
@@ -28,7 +28,7 @@ interface RepositoriesProvider {
   val studySessionRepository: StudySessionRepository
 
   // Calendar feature repo (model.calendar.PlannerRepository type)
-  val calendarRepository: PlannerRepositoryImpl
+  val calendarRepository: CalendarRepositoryImpl
 
   // To-Do
   val toDoRepository: ToDoRepository

--- a/app/src/main/java/com/android/sample/screens/CreatureEnvironment.kt
+++ b/app/src/main/java/com/android/sample/screens/CreatureEnvironment.kt
@@ -100,7 +100,7 @@ fun CreatureHouseCard(
 }
 
 @Composable
-private fun CreatureSprite(resId: Int, modifier: Modifier = Modifier, size: Dp = 120.dp) {
+fun CreatureSprite(resId: Int, modifier: Modifier = Modifier, size: Dp = 120.dp) {
   val inf = rememberInfiniteTransition(label = "float")
   val offset by
       inf.animateFloat(

--- a/app/src/main/java/com/android/sample/ui/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/calendar/CalendarScreen.kt
@@ -29,8 +29,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.sample.R
-import com.android.sample.model.StudyItem
-import com.android.sample.model.TaskType
+import com.android.sample.feature.schedule.data.calendar.StudyItem
+import com.android.sample.feature.schedule.data.calendar.TaskType
+import com.android.sample.feature.schedule.viewmodel.CalendarViewModel
 import com.android.sample.ui.theme.BackgroundDark
 import com.android.sample.ui.theme.BackgroundGradientEnd
 import com.android.sample.ui.theme.Blue

--- a/app/src/main/java/com/android/sample/ui/calendar/DayCell.kt
+++ b/app/src/main/java/com/android/sample/ui/calendar/DayCell.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -15,18 +14,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.android.sample.model.StudyItem
-import com.android.sample.ui.theme.PurpleBorder
-import com.android.sample.ui.theme.PurpleBottom
-import com.android.sample.ui.theme.PurpleSoft
-import com.android.sample.ui.theme.PurpleTop
-import com.android.sample.ui.theme.VioletSoft
+import com.android.sample.feature.schedule.data.calendar.StudyItem
 import java.time.LocalDate
 
 @Composable
@@ -39,8 +32,12 @@ fun DayCell(
     size: Dp = 48.dp
 ) {
   val hasTasks = tasks.isNotEmpty()
+  val cs = MaterialTheme.colorScheme
 
-  val selectedBrush = Brush.verticalGradient(colors = listOf(PurpleTop, PurpleBottom))
+  val selectedBrush = Brush.verticalGradient(colors = listOf(cs.primary, cs.secondary))
+  val unselectedBackgroundBrush =
+      Brush.verticalGradient(
+          listOf(cs.surfaceVariant.copy(alpha = 0.2f), cs.surfaceVariant.copy(alpha = 0.1f)))
 
   Box(
       modifier =
@@ -49,23 +46,17 @@ fun DayCell(
               .size(size)
               .clip(RoundedCornerShape(12.dp))
               .background(
-                  brush =
-                      if (isSelected) selectedBrush
-                      else Brush.verticalGradient(listOf(Color.Transparent, Color.Transparent)))
+                  brush = if (isSelected) selectedBrush else unselectedBackgroundBrush,
+                  shape = RoundedCornerShape(12.dp))
               .border(
                   width = 1.dp,
-                  color = if (isSelected) PurpleBorder else PurpleSoft.copy(alpha = 0.4f),
+                  color = if (isSelected) cs.primary else cs.onSurface.copy(alpha = 0.12f),
                   shape = RoundedCornerShape(12.dp))
               .clickable { onDateClick(date) },
       contentAlignment = Alignment.Center) {
         if (isSelected) {
-          Surface(
-              shape = RoundedCornerShape(12.dp),
-              color = Color.Transparent,
-              modifier =
-                  Modifier.size(size)
-                      .shadow(8.dp, RoundedCornerShape(12.dp))
-                      .background(selectedBrush, RoundedCornerShape(12.dp))) {}
+          // Optional: Add a subtle shadow/glow for selected state if desired
+          Box(modifier = Modifier.matchParentSize().shadow(8.dp, RoundedCornerShape(12.dp)))
         }
 
         Column(
@@ -77,8 +68,7 @@ fun DayCell(
                   text = date.dayOfMonth.toString(),
                   style =
                       MaterialTheme.typography.bodyLarge.copy(
-                          color =
-                              if (isSelected) Color.White else MaterialTheme.colorScheme.onSurface,
+                          color = if (isSelected) cs.onPrimary else cs.onSurface,
                           fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
                           fontSize = 16.sp),
                   textAlign = TextAlign.Center)
@@ -91,7 +81,7 @@ fun DayCell(
                     modifier = Modifier.padding(top = 2.dp)) {
                       repeat(tasks.size.coerceAtMost(3)) {
                         Canvas(modifier = Modifier.size(4.dp).padding(horizontal = 1.dp)) {
-                          drawCircle(color = VioletSoft.copy(alpha = 0.9f))
+                          drawCircle(color = cs.secondary.copy(alpha = 0.9f)) // Use a theme color
                         }
                       }
                     }

--- a/app/src/main/java/com/android/sample/ui/calendar/UpcomingEventsSection.kt
+++ b/app/src/main/java/com/android/sample/ui/calendar/UpcomingEventsSection.kt
@@ -1,7 +1,5 @@
 package com.android.sample.ui.calendar
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -12,23 +10,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.android.sample.R
-import com.android.sample.model.StudyItem
-import com.android.sample.model.TaskType
+import com.android.sample.feature.schedule.data.calendar.StudyItem
+import com.android.sample.feature.schedule.data.calendar.TaskType
+import com.android.sample.feature.weeks.ui.GlassSurface
 import com.android.sample.ui.theme.Blue
-import com.android.sample.ui.theme.DarkBlue
-import com.android.sample.ui.theme.DarkerBlue
-import com.android.sample.ui.theme.EventViolet
-import com.android.sample.ui.theme.LightViolet
 import com.android.sample.ui.theme.Pink
 import com.android.sample.ui.theme.PurpleCalendar
-import com.android.sample.ui.theme.PurplePrimary
 import com.android.sample.ui.theme.VioletLilas
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -39,20 +30,14 @@ fun UpcomingEventsSection(
     selectedDate: LocalDate,
     onAddTaskClick: (LocalDate) -> Unit,
     onTaskClick: (StudyItem) -> Unit,
+    modifier: Modifier = Modifier, // Added modifier
     title: String = stringResource(R.string.upcoming_events)
 ) {
   val sortedTasks = remember(tasks) { tasks.sortedBy { it.date } }
+  val cs = MaterialTheme.colorScheme
 
-  Card(
-      modifier =
-          Modifier.fillMaxWidth()
-              .padding(top = 20.dp)
-              .border(width = 1.dp, color = PurplePrimary, shape = RoundedCornerShape(20.dp))
-              .shadow(8.dp, RoundedCornerShape(20.dp)),
-      colors =
-          CardDefaults.cardColors(
-              containerColor =
-                  brushColor(Brush.verticalGradient(colors = listOf(DarkBlue, DarkerBlue)))),
+  GlassSurface(
+      modifier = modifier.fillMaxWidth(), // Use the passed modifier
       shape = RoundedCornerShape(20.dp)) {
         Column(modifier = Modifier.padding(20.dp)) {
           // Header Row
@@ -64,15 +49,16 @@ fun UpcomingEventsSection(
                     text = title,
                     style =
                         MaterialTheme.typography.titleMedium.copy(
-                            fontWeight = FontWeight.Bold, color = LightViolet))
+                            fontWeight = FontWeight.Bold, color = cs.onSurface))
 
                 // Properly sized and aligned "Add Event" button
-                FilledTonalButton(
+                Button( // Changed to Button for more control over background
                     onClick = { onAddTaskClick(selectedDate) },
                     shape = RoundedCornerShape(12.dp),
                     colors =
-                        ButtonDefaults.filledTonalButtonColors(
-                            containerColor = PurplePrimary, contentColor = Color.White),
+                        ButtonDefaults.buttonColors(
+                            containerColor = cs.primary, // Use primary color
+                            contentColor = cs.onPrimary),
                     contentPadding = PaddingValues(horizontal = 14.dp, vertical = 8.dp),
                     elevation = ButtonDefaults.buttonElevation(defaultElevation = 4.dp),
                     modifier = Modifier.height(38.dp).wrapContentWidth()) {
@@ -95,7 +81,7 @@ fun UpcomingEventsSection(
           if (sortedTasks.isEmpty()) {
             Text(
                 text = stringResource(R.string.no_upcoming_events),
-                color = EventViolet,
+                color = cs.onSurface.copy(alpha = 0.7f),
                 style = MaterialTheme.typography.bodyMedium,
                 modifier = Modifier.align(Alignment.CenterHorizontally))
           } else {
@@ -116,13 +102,10 @@ private fun EventCard(task: StudyItem, onTaskClick: (StudyItem) -> Unit) {
         TaskType.PERSONAL -> VioletLilas
         else -> PurpleCalendar
       }
+  val cs = MaterialTheme.colorScheme
 
-  Card(
-      modifier =
-          Modifier.fillMaxWidth()
-              .clickable { onTaskClick(task) }
-              .border(1.dp, PurplePrimary.copy(alpha = 0.4f), RoundedCornerShape(16.dp)),
-      colors = CardDefaults.cardColors(containerColor = DarkBlue),
+  GlassSurface( // Use GlassSurface for individual event cards
+      modifier = Modifier.fillMaxWidth().clickable { onTaskClick(task) },
       shape = RoundedCornerShape(16.dp)) {
         Column(modifier = Modifier.padding(16.dp)) {
           Row(verticalAlignment = Alignment.CenterVertically) {
@@ -130,7 +113,8 @@ private fun EventCard(task: StudyItem, onTaskClick: (StudyItem) -> Unit) {
                 text = task.date.format(DateTimeFormatter.ofPattern("MMM dd")),
                 style =
                     MaterialTheme.typography.labelLarge.copy(
-                        color = EventViolet, fontWeight = FontWeight.Medium),
+                        color = cs.primary, // Use theme primary
+                        fontWeight = FontWeight.Medium),
                 modifier = Modifier.weight(1f))
             Surface(color = tagColor.copy(alpha = 0.15f), shape = RoundedCornerShape(8.dp)) {
               Text(
@@ -147,7 +131,8 @@ private fun EventCard(task: StudyItem, onTaskClick: (StudyItem) -> Unit) {
               text = task.title,
               style =
                   MaterialTheme.typography.bodyLarge.copy(
-                      color = Color.White, fontWeight = FontWeight.SemiBold))
+                      color = cs.onSurface, // Use theme onSurface
+                      fontWeight = FontWeight.SemiBold))
 
           val taskTime =
               when (task) {
@@ -164,13 +149,11 @@ private fun EventCard(task: StudyItem, onTaskClick: (StudyItem) -> Unit) {
             Spacer(Modifier.height(2.dp))
             Text(
                 text = taskTime,
-                style = MaterialTheme.typography.labelSmall.copy(color = EventViolet))
+                style =
+                    MaterialTheme.typography.labelSmall.copy(
+                        color = cs.onSurface.copy(alpha = 0.7f)) // Use theme onSurface
+                )
           }
         }
       }
 }
-
-// Helper to use Brush as background color in Card
-@Composable
-fun brushColor(brush: Brush): Color =
-    Color.Transparent.copy(alpha = 0f).also { Box(Modifier.background(brush)) }

--- a/app/src/main/java/com/android/sample/ui/planner/ActivityItem.kt
+++ b/app/src/main/java/com/android/sample/ui/planner/ActivityItem.kt
@@ -6,14 +6,13 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -29,7 +28,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
@@ -41,15 +39,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.sample.R
-import com.android.sample.model.planner.Class
-import com.android.sample.model.planner.ClassAttendance
-import com.android.sample.model.planner.ClassType
+import com.android.sample.feature.schedule.data.planner.Class
+import com.android.sample.feature.schedule.data.planner.ClassAttendance
+import com.android.sample.feature.schedule.data.planner.ClassType
+import com.android.sample.feature.weeks.ui.GlassSurface
 import com.android.sample.ui.theme.AccentViolet
 import com.android.sample.ui.theme.CustomBlue
 import com.android.sample.ui.theme.CustomGreen
-import com.android.sample.ui.theme.DarkCardItem
 import com.android.sample.ui.theme.LightBlueAccent
-import com.android.sample.ui.theme.MidDarkCard
 import com.android.sample.ui.theme.TextLight
 import java.time.format.DateTimeFormatter
 import kotlin.math.max
@@ -67,146 +64,136 @@ fun ActivityItem(activity: Class, attendanceRecord: ClassAttendance?, onClick: (
                   repeatMode = RepeatMode.Reverse),
           label = "activityGlowAlpha")
 
-  Box(
-      modifier =
-          Modifier.fillMaxWidth()
-              .clip(RoundedCornerShape(14.dp))
-              .background(
-                  Brush.verticalGradient(
-                      colors =
-                          listOf(
-                              MidDarkCard.copy(alpha = 0.95f), DarkCardItem.copy(alpha = 0.98f))))
-              .border(
-                  width = 1.dp,
-                  brush =
-                      Brush.verticalGradient(
-                          colors = listOf(AccentViolet.copy(alpha = 0.3f), Color.Transparent)),
-                  shape = RoundedCornerShape(14.dp))
-              .shadow(elevation = 4.dp, shape = RoundedCornerShape(14.dp))
-              .clickable(onClick = onClick)
-              .padding(14.dp)) {
+  GlassSurface(
+      modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+      shape = RoundedCornerShape(14.dp)) {
         Box(
             modifier =
-                Modifier.matchParentSize().drawBehind {
-                  val center = Offset(size.width / 2f, size.height / 2f)
-                  val radius = max(size.width, size.height) * 0.7f
+                Modifier.fillMaxSize()
+                    .drawBehind { // CHANGED: Replaced matchParentSize() with fillMaxSize()
+                      val center = Offset(size.width / 2f, size.height / 2f)
+                      val radius = max(size.width, size.height) * 0.7f
 
-                  drawCircle(
-                      brush =
-                          Brush.radialGradient(
-                              colors =
-                                  listOf(AccentViolet.copy(alpha = glowAlpha), Color.Transparent),
-                              center = center,
-                              radius = radius),
-                      radius = radius,
-                      center = center)
-                })
+                      drawCircle(
+                          brush =
+                              Brush.radialGradient(
+                                  colors =
+                                      listOf(
+                                          AccentViolet.copy(alpha = glowAlpha), Color.Transparent),
+                                  center = center,
+                                  radius = radius),
+                          radius = radius,
+                          center = center)
+                    }
+                    .padding(14.dp)) {
+              Column {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                  val iconColor =
+                      when (activity.type) {
+                        ClassType.LECTURE -> LightBlueAccent
+                        ClassType.EXERCISE -> CustomGreen
+                        ClassType.LAB -> AccentViolet
+                      }
 
-        Column {
-          Row(verticalAlignment = Alignment.CenterVertically) {
-            val iconColor =
-                when (activity.type) {
-                  ClassType.LECTURE -> LightBlueAccent
-                  ClassType.EXERCISE -> CustomGreen
-                  ClassType.LAB -> AccentViolet
+                  val classTypeText =
+                      when (activity.type) {
+                        ClassType.LECTURE -> stringResource(R.string.lecture_type)
+                        ClassType.EXERCISE -> stringResource(R.string.exercise_type)
+                        ClassType.LAB -> stringResource(R.string.lab_type)
+                      }
+
+                  Icon(
+                      painter =
+                          painterResource(
+                              id =
+                                  when (activity.type) {
+                                    ClassType.LECTURE -> R.drawable.ic_lecture
+                                    ClassType.EXERCISE -> R.drawable.ic_exercise
+                                    ClassType.LAB -> R.drawable.ic_lab
+                                  }),
+                      contentDescription =
+                          classTypeText, // Content description from string resource
+                      tint = iconColor.copy(alpha = 0.9f),
+                      modifier = Modifier.size(28.dp).shadow(6.dp, shape = CircleShape))
+
+                  Spacer(modifier = Modifier.width(10.dp))
+
+                  Text(
+                      text = "${activity.courseName} (${classTypeText})",
+                      color = TextLight,
+                      fontWeight = FontWeight.Bold,
+                      fontSize = 16.sp)
                 }
 
-            val classTypeText =
-                when (activity.type) {
-                  ClassType.LECTURE -> stringResource(R.string.lecture_type)
-                  ClassType.EXERCISE -> stringResource(R.string.exercise_type)
-                  ClassType.LAB -> stringResource(R.string.lab_type)
+                Spacer(modifier = Modifier.height(6.dp))
+
+                Text(
+                    text =
+                        "${activity.startTime.format(DateTimeFormatter.ofPattern("HH:mm"))} - ${activity.endTime.format(DateTimeFormatter.ofPattern("HH:mm"))}",
+                    color = TextLight.copy(alpha = 0.75f),
+                    fontSize = 13.sp)
+                Text(
+                    text = "${activity.location} • ${activity.instructor}",
+                    color = TextLight.copy(alpha = 0.7f),
+                    fontSize = 12.sp)
+
+                attendanceRecord?.let {
+                  Spacer(modifier = Modifier.height(10.dp))
+                  Divider(
+                      color =
+                          MaterialTheme.colorScheme.onSurface.copy(
+                              alpha = 0.08f), // Using theme color
+                      thickness = 0.5.dp,
+                      modifier = Modifier.padding(vertical = 4.dp))
+                  Row(
+                      modifier = Modifier.fillMaxWidth(),
+                      verticalAlignment = Alignment.CenterVertically,
+                      horizontalArrangement = Arrangement.SpaceBetween) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                          Icon(
+                              painter = painterResource(id = R.drawable.ic_check_circle),
+                              contentDescription =
+                                  stringResource(
+                                      R.string.attended_status, ""), // Content desc for attended
+                              tint = CustomGreen, // Custom green color
+                              modifier = Modifier.size(16.dp))
+                          Spacer(modifier = Modifier.width(4.dp))
+                          Text(
+                              text =
+                                  stringResource(
+                                      R.string.attended_status,
+                                      it.attendance.name
+                                          .replace("_", " ")
+                                          .lowercase()
+                                          .replaceFirstChar { c -> c.uppercase() }),
+                              color = CustomGreen,
+                              fontSize = 12.sp,
+                              fontWeight = FontWeight.Medium)
+                        }
+
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                          Icon(
+                              painter = painterResource(id = R.drawable.ic_done_all),
+                              contentDescription =
+                                  stringResource(
+                                      R.string.completed_status, ""), // Content desc for completed
+                              tint = CustomBlue, // Custom blue color
+                              modifier = Modifier.size(16.dp))
+                          Spacer(modifier = Modifier.width(4.dp))
+                          Text(
+                              text =
+                                  stringResource(
+                                      R.string.completed_status,
+                                      it.completion.name.lowercase().replaceFirstChar { c ->
+                                        c.uppercase()
+                                      }),
+                              color = CustomBlue,
+                              fontSize = 12.sp,
+                              fontWeight = FontWeight.Medium)
+                        }
+                      }
                 }
-
-            Icon(
-                painter =
-                    painterResource(
-                        id =
-                            when (activity.type) {
-                              ClassType.LECTURE -> R.drawable.ic_lecture
-                              ClassType.EXERCISE -> R.drawable.ic_exercise
-                              ClassType.LAB -> R.drawable.ic_lab
-                            }),
-                contentDescription = classTypeText, // Content description from string resource
-                tint = iconColor.copy(alpha = 0.9f),
-                modifier = Modifier.size(28.dp).shadow(6.dp, shape = CircleShape))
-
-            Spacer(modifier = Modifier.width(10.dp))
-
-            Text(
-                text = "${activity.courseName} (${classTypeText})",
-                color = TextLight,
-                fontWeight = FontWeight.Bold,
-                fontSize = 16.sp)
-          }
-
-          Spacer(modifier = Modifier.height(6.dp))
-
-          Text(
-              text =
-                  "${activity.startTime.format(DateTimeFormatter.ofPattern("HH:mm"))} - ${activity.endTime.format(DateTimeFormatter.ofPattern("HH:mm"))}",
-              color = TextLight.copy(alpha = 0.75f),
-              fontSize = 13.sp)
-          Text(
-              text = "${activity.location} • ${activity.instructor}",
-              color = TextLight.copy(alpha = 0.7f),
-              fontSize = 12.sp)
-
-          attendanceRecord?.let {
-            Spacer(modifier = Modifier.height(10.dp))
-            Divider(
-                color =
-                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f), // Using theme color
-                thickness = 0.5.dp,
-                modifier = Modifier.padding(vertical = 4.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween) {
-                  Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_check_circle),
-                        contentDescription =
-                            stringResource(
-                                R.string.attended_status, ""), // Content desc for attended
-                        tint = CustomGreen, // Custom green color
-                        modifier = Modifier.size(16.dp))
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text =
-                            stringResource(
-                                R.string.attended_status,
-                                it.attendance.name.replace("_", " ").lowercase().replaceFirstChar {
-                                    c ->
-                                  c.uppercase()
-                                }),
-                        color = CustomGreen,
-                        fontSize = 12.sp,
-                        fontWeight = FontWeight.Medium)
-                  }
-
-                  Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_done_all),
-                        contentDescription =
-                            stringResource(
-                                R.string.completed_status, ""), // Content desc for completed
-                        tint = CustomBlue, // Custom blue color
-                        modifier = Modifier.size(16.dp))
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text =
-                            stringResource(
-                                R.string.completed_status,
-                                it.completion.name.lowercase().replaceFirstChar { c ->
-                                  c.uppercase()
-                                }),
-                        color = CustomBlue,
-                        fontSize = 12.sp,
-                        fontWeight = FontWeight.Medium)
-                  }
-                }
-          }
-        }
+              }
+            }
       }
 }

--- a/app/src/main/java/com/android/sample/ui/planner/ClassAttendanceModal.kt
+++ b/app/src/main/java/com/android/sample/ui/planner/ClassAttendanceModal.kt
@@ -213,7 +213,7 @@ fun ClassAttendanceModal(
                 ButtonDefaults.outlinedButtonColors(contentColor = PurpleText.copy(alpha = 0.9f)),
         ) {
           Text(
-              stringResource(R.string.close),
+              stringResource(R.string.cancel),
               color = TextLight.copy(alpha = 0.7f),
               fontWeight = FontWeight.SemiBold,
               fontSize = 16.sp)

--- a/app/src/main/java/com/android/sample/ui/planner/ClassAttendanceModal.kt
+++ b/app/src/main/java/com/android/sample/ui/planner/ClassAttendanceModal.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -105,7 +106,7 @@ fun ClassAttendanceModal(
               IconButton(onClick = onDismiss) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_close), // Ensure ic_close exists
-                    contentDescription = "Close",
+                    contentDescription = stringResource(R.string.close),
                     tint = TextLight.copy(alpha = 0.8f),
                     modifier = Modifier.size(28.dp) // Larger close icon
                     )
@@ -115,7 +116,7 @@ fun ClassAttendanceModal(
       text = {
         Column(modifier = Modifier.padding(top = 4.dp, bottom = 8.dp)) {
           Text(
-              text = "Confirm your attendance & completion",
+              text = stringResource(R.string.confirm_attendance_completion),
               color = TextLight.copy(alpha = 0.8f),
               fontSize = 14.sp,
               modifier = Modifier.padding(bottom = 20.dp) // More space after subtitle
@@ -123,7 +124,7 @@ fun ClassAttendanceModal(
 
           // Attendance Section
           Text(
-              text = "Did you attend this class?",
+              text = stringResource(R.string.did_you_attend_class),
               color = TextLight,
               fontWeight = FontWeight.SemiBold,
               fontSize = 15.sp,
@@ -151,9 +152,9 @@ fun ClassAttendanceModal(
           Text(
               text =
                   when (classItem.type) {
-                    ClassType.LECTURE -> "Did you finish reviewing today’s lecture materials?"
-                    ClassType.EXERCISE -> "Did you finish the exercise?"
-                    ClassType.LAB -> "Did you finish the lab?"
+                    ClassType.LECTURE -> stringResource(R.string.did_you_review_lecture)
+                    ClassType.EXERCISE -> stringResource(R.string.did_you_finish_exercise)
+                    ClassType.LAB -> stringResource(R.string.did_you_finish_lab)
                   },
               color = TextLight,
               fontWeight = FontWeight.SemiBold,
@@ -190,7 +191,11 @@ fun ClassAttendanceModal(
                     disabledContainerColor = PurplePrimary.copy(alpha = 0.35f),
                     disabledContentColor = Color.White.copy(alpha = .7f)),
             contentPadding = PaddingValues(vertical = 14.dp)) {
-              Text("Save", color = Color.White, fontWeight = FontWeight.Bold, fontSize = 16.sp)
+              Text(
+                  stringResource(R.string.save),
+                  color = Color.White,
+                  fontWeight = FontWeight.Bold,
+                  fontSize = 16.sp)
             }
       },
       dismissButton = {
@@ -208,7 +213,7 @@ fun ClassAttendanceModal(
                 ButtonDefaults.outlinedButtonColors(contentColor = PurpleText.copy(alpha = 0.9f)),
         ) {
           Text(
-              "Cancel",
+              stringResource(R.string.close),
               color = TextLight.copy(alpha = 0.7f),
               fontWeight = FontWeight.SemiBold,
               fontSize = 16.sp)

--- a/app/src/main/java/com/android/sample/ui/planner/ClassAttendanceModal.kt
+++ b/app/src/main/java/com/android/sample/ui/planner/ClassAttendanceModal.kt
@@ -1,7 +1,5 @@
 package com.android.sample.ui.planner
 
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -30,7 +28,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
@@ -38,15 +35,18 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.sample.R
-import com.android.sample.model.planner.AttendanceStatus
-import com.android.sample.model.planner.Class
-import com.android.sample.model.planner.ClassType
-import com.android.sample.model.planner.CompletionStatus
+import com.android.sample.feature.schedule.data.planner.AttendanceStatus
+import com.android.sample.feature.schedule.data.planner.Class
+import com.android.sample.feature.schedule.data.planner.ClassType
+import com.android.sample.feature.schedule.data.planner.CompletionStatus
 import com.android.sample.ui.theme.AccentViolet
 import com.android.sample.ui.theme.DarkCardItem
 import com.android.sample.ui.theme.DarknightViolet
 import com.android.sample.ui.theme.LightBlueAccent
 import com.android.sample.ui.theme.MidDarkCard
+import com.android.sample.ui.theme.PurpleBorder
+import com.android.sample.ui.theme.PurplePrimary
+import com.android.sample.ui.theme.PurpleText
 import com.android.sample.ui.theme.TextLight
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -61,6 +61,7 @@ fun ClassAttendanceModal(
 ) {
   var attendanceStatus by remember { mutableStateOf(initialAttendance) }
   var completionStatus by remember { mutableStateOf(initialCompletion) }
+  val canSave = attendanceStatus != null && completionStatus != null
 
   // Define modal background gradient
   val modalBackgroundBrush =
@@ -175,41 +176,43 @@ fun ClassAttendanceModal(
       },
       confirmButton = {
         Button(
-            onClick = {
-              val finalAttendance =
-                  attendanceStatus ?: AttendanceStatus.NO // Default to NO if not selected
-              val finalCompletion =
-                  completionStatus ?: CompletionStatus.NO // Default to NO if not selected
-              onSave(finalAttendance, finalCompletion)
-            },
+            onClick = { onSave(attendanceStatus!!, completionStatus!!) },
+            enabled = canSave,
             modifier =
                 Modifier.fillMaxWidth()
                     .height(50.dp) // Slightly taller button
-                    .padding(horizontal = 8.dp) // Padding for button within dialog
-                    .shadow(6.dp, RoundedCornerShape(12.dp), clip = false), // Subtle shadow
+                    .padding(horizontal = 8.dp), // Padding for button within dialog
+            // .shadow(6.dp, RoundedCornerShape(12.dp), clip = false), // Subtle shadow
             shape = RoundedCornerShape(12.dp),
-            colors = ButtonDefaults.buttonColors(containerColor = AccentViolet),
-            contentPadding = PaddingValues(0.dp)) {
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = PurplePrimary,
+                    disabledContainerColor = PurplePrimary.copy(alpha = 0.35f),
+                    disabledContentColor = Color.White.copy(alpha = .7f)),
+            contentPadding = PaddingValues(vertical = 14.dp)) {
               Text("Save", color = Color.White, fontWeight = FontWeight.Bold, fontSize = 16.sp)
             }
       },
       dismissButton = {
         OutlinedButton(
             onClick = onDismiss,
+            border = BorderStroke(1.dp, PurpleBorder.copy(alpha = 0.6f)),
             modifier =
                 Modifier.fillMaxWidth()
                     .height(50.dp) // Slightly taller button
                     .padding(horizontal = 8.dp) // Padding for button within dialog
                     .padding(bottom = 8.dp), // Padding from the bottom of the dialog
             shape = RoundedCornerShape(12.dp),
-            border = BorderStroke(1.dp, TextLight.copy(alpha = 0.3f)), // Lighter border
-            colors = ButtonDefaults.outlinedButtonColors(contentColor = TextLight)) {
-              Text(
-                  "Cancel",
-                  color = TextLight.copy(alpha = 0.7f),
-                  fontWeight = FontWeight.SemiBold,
-                  fontSize = 16.sp)
-            }
+            // border = BorderStroke(1.dp, TextLight.copy(alpha = 0.3f)), // Lighter border
+            colors =
+                ButtonDefaults.outlinedButtonColors(contentColor = PurpleText.copy(alpha = 0.9f)),
+        ) {
+          Text(
+              "Cancel",
+              color = TextLight.copy(alpha = 0.7f),
+              fontWeight = FontWeight.SemiBold,
+              fontSize = 16.sp)
+        }
       })
 }
 
@@ -220,29 +223,23 @@ fun ChoiceButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-  val backgroundColor by
-      animateColorAsState(
-          targetValue = if (isSelected) AccentViolet.copy(alpha = 0.9f) else DarkCardItem,
-          animationSpec = tween(durationMillis = 200),
-          label = "choiceButtonBgColor")
-  val textColor by
-      animateColorAsState(
-          targetValue = if (isSelected) Color.White else TextLight.copy(alpha = 0.8f),
-          animationSpec = tween(durationMillis = 200),
-          label = "choiceButtonTextColor")
+  val bg = if (isSelected) PurplePrimary else DarkCardItem
+  val fg = if (isSelected) Color.White else TextLight.copy(alpha = 0.85f)
+  val border = if (isSelected) BorderStroke(1.dp, PurpleBorder.copy(alpha = 0.45f)) else null
 
   Button(
       onClick = onClick,
-      colors = ButtonDefaults.buttonColors(containerColor = backgroundColor),
-      shape = RoundedCornerShape(10.dp), // Slightly more rounded
-      modifier =
-          modifier
-              .height(48.dp) // Consistent button height
-              .shadow(
-                  elevation = if (isSelected) 6.dp else 2.dp, // Dynamic shadow for selected state
-                  shape = RoundedCornerShape(10.dp),
-                  clip = false),
-      contentPadding = PaddingValues(vertical = 12.dp, horizontal = 8.dp)) {
-        Text(text, color = textColor, fontSize = 13.sp, fontWeight = FontWeight.SemiBold)
+      shape = RoundedCornerShape(12.dp),
+      colors = ButtonDefaults.buttonColors(containerColor = bg, contentColor = fg),
+      border = border,
+      elevation =
+          ButtonDefaults.buttonElevation(
+              defaultElevation = 0.dp,
+              pressedElevation = 0.dp,
+              focusedElevation = 0.dp,
+              disabledElevation = 0.dp),
+      contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp),
+      modifier = modifier.height(44.dp)) {
+        Text(text, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
       }
 }

--- a/app/src/main/java/com/android/sample/ui/planner/PetHeader.kt
+++ b/app/src/main/java/com/android/sample/ui/planner/PetHeader.kt
@@ -1,174 +1,24 @@
 package com.android.sample.ui.planner
 
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Star
-import androidx.compose.material3.AssistChip
-import androidx.compose.material3.AssistChipDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.android.sample.R
-import com.android.sample.ui.theme.AccentViolet
-import com.android.sample.ui.theme.DarkCardItem
-import com.android.sample.ui.theme.LightBlueAccent
-import com.android.sample.ui.theme.StatBarHeart
-import com.android.sample.ui.theme.StatBarLightbulb
-import com.android.sample.ui.theme.StatBarLightning
-import com.android.sample.ui.theme.TextLight
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun PetHeader(level: Int, modifier: Modifier = Modifier, onEdumonNameClick: () -> Unit) {
-  val pulseAlpha by
-      rememberInfiniteTransition(label = "petGlow")
-          .animateFloat(
-              initialValue = 0.3f,
-              targetValue = 0.9f,
-              animationSpec =
-                  infiniteRepeatable(
-                      animation = tween(durationMillis = 2500, easing = LinearEasing),
-                      repeatMode = RepeatMode.Reverse),
-              label = "pulseAlpha")
-
-  Box(modifier = modifier.fillMaxWidth().height(200.dp).testTag(PlannerScreenTestTags.PET_HEADER)) {
-    Image(
-        painter = painterResource(id = R.drawable.epfl_amphi_background),
-        contentDescription = stringResource(R.string.app_name), // Generic content description
-        modifier = Modifier.fillMaxSize(),
-        contentScale = ContentScale.Crop)
-
-    Row(
-        modifier =
-            Modifier.fillMaxWidth()
-                .padding(vertical = 20.dp, horizontal = 16.dp)
-                .align(Alignment.Center)) {
-          Box(modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp, vertical = 20.dp)) {
-            Column(
-                modifier = Modifier.align(Alignment.CenterStart),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-                horizontalAlignment = Alignment.Start) {
-                  StatBar(icon = "❤️", percent = 0.9f, color = StatBarHeart)
-                  StatBar(icon = "💡", percent = 0.85f, color = StatBarLightbulb)
-                  StatBar(icon = "⚡", percent = 0.7f, color = StatBarLightning)
-                }
-
-            Column(
-                modifier = Modifier.align(Alignment.Center),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center) {
-                  Box(
-                      modifier =
-                          Modifier.size(130.dp)
-                              .background(
-                                  brush =
-                                      Brush.radialGradient(
-                                          colors =
-                                              listOf(
-                                                  LightBlueAccent.copy(alpha = pulseAlpha * 0.6f),
-                                                  Color.Transparent)),
-                                  shape = RoundedCornerShape(100.dp)),
-                      contentAlignment = Alignment.Center) {
-                        Image(
-                            painter = painterResource(id = R.drawable.edumon),
-                            contentDescription = "EduMon",
-                            modifier = Modifier.size(100.dp))
-                      }
-                  Spacer(modifier = Modifier.height(8.dp))
-
-                  AssistChip(
-                      onClick = { /* Not clickable for primary action, just info */},
-                      label = { Text("Lv $level", color = AccentViolet) },
-                      // label = { Text(stringResource(R.string, level), color = AccentViolet) },
-                      leadingIcon = {
-                        Icon(
-                            Icons.Outlined.Star,
-                            null,
-                            tint = AccentViolet,
-                            modifier = Modifier.size(16.dp))
-                      },
-                      colors =
-                          AssistChipDefaults.assistChipColors(
-                              containerColor = DarkCardItem.copy(alpha = 0.8f),
-                              labelColor = AccentViolet,
-                              leadingIconContentColor = AccentViolet),
-                      border = BorderStroke(1.dp, AccentViolet.copy(alpha = 0.5f)),
-                      modifier = Modifier.offset(y = (-5).dp))
-                }
-          }
-        }
-
-    Box(
-        modifier =
-            Modifier.align(Alignment.TopEnd)
-                .padding(top = 16.dp, end = 16.dp)
-                .background(DarkCardItem, RoundedCornerShape(20.dp))
-                .padding(horizontal = 16.dp, vertical = 6.dp)
-                .clickable(onClick = onEdumonNameClick)
-                .testTag("petNameBox")) {
-          Text(
-              stringResource(R.string.edumon_profile),
-              color = TextLight.copy(alpha = 0.8f),
-              fontSize = 13.sp)
-        }
-  }
-}
+import com.android.sample.screens.CreatureHouseCard
 
 @Composable
-fun StatBar(icon: String, percent: Float, color: Color) {
-  Row(verticalAlignment = Alignment.CenterVertically) {
-    Text(icon, fontSize = 16.sp)
-    Spacer(modifier = Modifier.width(4.dp))
-    Box(
-        modifier =
-            Modifier.width(70.dp)
-                .height(10.dp)
-                .background(
-                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f),
-                    RoundedCornerShape(10.dp))) { // Using theme color
-          Box(
-              modifier =
-                  Modifier.fillMaxHeight()
-                      .fillMaxWidth(percent)
-                      .background(color, RoundedCornerShape(10.dp)))
-        }
-    Spacer(modifier = Modifier.width(4.dp))
-    Text("${(percent * 100).toInt()}%", color = TextLight.copy(alpha = 0.8f), fontSize = 12.sp)
+fun PetHeader(
+    level: Int,
+    modifier: Modifier = Modifier,
+    environmentResId: Int = R.drawable.epfl_amphi_background,
+    creatureResId: Int = R.drawable.edumon
+) {
+  Box(modifier = modifier.fillMaxWidth()) {
+    // Exact same card as on the Home screen
+    CreatureHouseCard(
+        creatureResId = creatureResId,
+        level = level,
+        environmentResId = environmentResId,
+        modifier = Modifier.fillMaxWidth())
   }
 }

--- a/app/src/main/java/com/android/sample/ui/planner/PlannerScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/planner/PlannerScreen.kt
@@ -26,9 +26,9 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.sample.R
 import com.android.sample.data.Priority
-import com.android.sample.model.planner.*
+import com.android.sample.feature.schedule.data.planner.WellnessEventType
+import com.android.sample.feature.schedule.viewmodel.PlannerViewModel
 import com.android.sample.ui.theme.*
-import com.android.sample.ui.viewmodel.PlannerViewModel
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.flow.collectLatest
@@ -75,10 +75,7 @@ fun PlannerScreen(viewModel: PlannerViewModel = viewModel()) {
             contentPadding = PaddingValues(vertical = 16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)) {
               item {
-                PetHeader(
-                    level = 5,
-                    modifier = Modifier.testTag(PlannerScreenTestTags.PET_HEADER),
-                    onEdumonNameClick = { /* Navigate to pet profile */})
+                PetHeader(level = 5, modifier = Modifier.testTag(PlannerScreenTestTags.PET_HEADER))
               }
               item {
                 PlannerGlowCard {

--- a/app/src/main/java/com/android/sample/ui/planner/WellnessEventItem.kt
+++ b/app/src/main/java/com/android/sample/ui/planner/WellnessEventItem.kt
@@ -1,47 +1,25 @@
+// file: com/android/sample/ui/planner/WellnessEventItem.kt
 package com.android.sample.ui.planner
 
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.sample.R
-import com.android.sample.model.planner.WellnessEventType
-import com.android.sample.ui.theme.DarkCardItem
-import com.android.sample.ui.theme.MidDarkCard
-import com.android.sample.ui.theme.TextLight
-import kotlin.math.max
+import com.android.sample.feature.schedule.data.planner.WellnessEventType
 
 @Composable
 fun WellnessEventItem(
@@ -49,96 +27,56 @@ fun WellnessEventItem(
     time: String,
     description: String,
     eventType: WellnessEventType,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
-  val infiniteTransition = rememberInfiniteTransition(label = "wellnessGlowAnim")
-  val glowAlpha by
-      infiniteTransition.animateFloat(
-          initialValue = 0.15f,
-          targetValue = 0.35f,
-          animationSpec =
-              infiniteRepeatable(
-                  animation = tween(durationMillis = 2800, easing = LinearEasing),
-                  repeatMode = RepeatMode.Reverse),
-          label = "wellnessGlowAlpha")
+  val cs = MaterialTheme.colorScheme
+  val accent = eventType.primaryColor
 
-  val iconColor = eventType.primaryColor
-  val containerColor = iconColor.copy(alpha = 0.1f)
-  val borderColor = iconColor.copy(alpha = 0.3f)
-
-  Box(
+  Row(
       modifier =
-          Modifier.fillMaxWidth()
-              .clip(RoundedCornerShape(14.dp))
-              .background(
-                  Brush.verticalGradient(
-                      colors =
-                          listOf(
-                              MidDarkCard.copy(alpha = 0.95f), DarkCardItem.copy(alpha = 0.98f))))
-              .border(
-                  width = 1.dp,
-                  brush =
-                      Brush.verticalGradient(
-                          colors = listOf(iconColor.copy(alpha = 0.3f), Color.Transparent)),
-                  shape = RoundedCornerShape(14.dp))
-              .shadow(elevation = 4.dp, shape = RoundedCornerShape(14.dp))
+          modifier
+              .fillMaxWidth()
+              .clip(RoundedCornerShape(12.dp))
               .clickable(onClick = onClick)
-              .padding(14.dp)) {
+              .padding(vertical = 6.dp),
+      verticalAlignment = Alignment.CenterVertically) {
+        // Left badge (same style as Classes rows)
         Box(
             modifier =
-                Modifier.matchParentSize().drawBehind {
-                  val center = Offset(size.width / 2f, size.height / 2f)
-                  val radius = max(size.width, size.height) * 0.7f
+                Modifier.size(36.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(accent.copy(alpha = .16f))
+                    .border(1.dp, accent.copy(alpha = .32f), RoundedCornerShape(10.dp)),
+            contentAlignment = Alignment.Center) {
+              Icon(
+                  painter = painterResource(id = eventType.iconRes),
+                  contentDescription = null,
+                  tint = accent,
+                  modifier = Modifier.size(20.dp))
+            }
 
-                  drawCircle(
-                      brush =
-                          Brush.radialGradient(
-                              colors =
-                                  listOf(
-                                      iconColor.copy(alpha = glowAlpha * 0.8f), Color.Transparent),
-                              center = center,
-                              radius = radius),
-                      radius = radius,
-                      center = center)
-                })
+        Spacer(Modifier.width(10.dp))
 
-        Row(verticalAlignment = Alignment.CenterVertically) {
-          Box(
-              modifier =
-                  Modifier.size(40.dp)
-                      .background(color = containerColor, shape = RoundedCornerShape(10.dp))
-                      .border(width = 1.dp, color = borderColor, shape = RoundedCornerShape(10.dp)),
-              contentAlignment = Alignment.Center) {
-                Icon(
-                    painter = painterResource(id = eventType.iconRes), // Using enum icon
-                    contentDescription = title, // Content description as title
-                    tint = iconColor,
-                    modifier = Modifier.size(24.dp))
-              }
-
-          Spacer(modifier = Modifier.width(12.dp))
-
-          Column(modifier = Modifier.weight(1f)) {
-            Text(text = title, color = TextLight, fontWeight = FontWeight.Bold, fontSize = 16.sp)
-
-            Spacer(modifier = Modifier.height(2.dp))
-
-            Text(text = time, color = iconColor, fontSize = 13.sp, fontWeight = FontWeight.Medium)
-
-            Spacer(modifier = Modifier.height(4.dp))
-
-            Text(
-                text = description,
-                color = TextLight.copy(alpha = 0.7f),
-                fontSize = 12.sp,
-                lineHeight = 14.sp)
+        Column(Modifier.weight(1f)) {
+          Text(
+              text = title,
+              color = cs.onSurface,
+              fontWeight = FontWeight.SemiBold,
+              fontSize = 16.sp)
+          Spacer(Modifier.height(2.dp))
+          Text(text = time, color = accent, fontSize = 12.sp, fontWeight = FontWeight.Medium)
+          if (description.isNotBlank()) {
+            Text(text = description, color = cs.onSurface.copy(alpha = 0.65f), fontSize = 12.sp)
           }
-
-          Icon(
-              painter = painterResource(id = R.drawable.ic_arrow_right),
-              contentDescription = stringResource(R.string.details),
-              tint = TextLight.copy(alpha = 0.5f),
-              modifier = Modifier.size(20.dp))
         }
+
+        Spacer(Modifier.width(6.dp))
+
+        Icon(
+            painter = painterResource(R.drawable.ic_arrow_right),
+            contentDescription = stringResource(R.string.details),
+            tint = cs.onSurface.copy(alpha = 0.50f),
+            modifier = Modifier.size(20.dp))
       }
 }

--- a/app/src/main/java/com/android/sample/ui/schedule/AdaptivePlanner.kt
+++ b/app/src/main/java/com/android/sample/ui/schedule/AdaptivePlanner.kt
@@ -1,9 +1,9 @@
 package com.android.sample.ui.schedule
 
-import com.android.sample.model.schedule.EventKind
-import com.android.sample.model.schedule.Priority
-import com.android.sample.model.schedule.ScheduleEvent
-import com.android.sample.model.schedule.SourceTag
+import com.android.sample.feature.schedule.data.schedule.EventKind
+import com.android.sample.feature.schedule.data.schedule.Priority
+import com.android.sample.feature.schedule.data.schedule.ScheduleEvent
+import com.android.sample.feature.schedule.data.schedule.SourceTag
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalTime

--- a/app/src/main/java/com/android/sample/ui/schedule/DayTabContent.kt
+++ b/app/src/main/java/com/android/sample/ui/schedule/DayTabContent.kt
@@ -1,0 +1,324 @@
+package com.android.sample.ui.schedule
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.android.sample.R
+import com.android.sample.feature.schedule.data.planner.AttendanceStatus
+import com.android.sample.feature.schedule.data.planner.Class
+import com.android.sample.feature.schedule.data.planner.ClassAttendance
+import com.android.sample.feature.schedule.data.planner.ClassType
+import com.android.sample.feature.schedule.data.planner.CompletionStatus
+import com.android.sample.feature.schedule.data.planner.WellnessEventType
+import com.android.sample.feature.schedule.viewmodel.ScheduleUiState
+import com.android.sample.feature.schedule.viewmodel.ScheduleViewModel
+import com.android.sample.feature.weeks.ui.DailyObjectivesSection
+import com.android.sample.feature.weeks.ui.GlassSurface
+import com.android.sample.feature.weeks.viewmodel.ObjectivesViewModel
+import com.android.sample.ui.planner.ClassAttendanceModal
+import com.android.sample.ui.planner.WellnessEventItem
+import com.android.sample.ui.theme.AccentViolet
+import com.android.sample.ui.theme.CustomGreen
+import com.android.sample.ui.theme.LightBlueAccent
+import com.android.sample.ui.theme.Pink
+import com.android.sample.ui.theme.PurplePrimary
+import com.android.sample.ui.theme.StatBarLightbulb
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+@Composable
+fun DayTabContent(
+    vm: ScheduleViewModel,
+    state: ScheduleUiState,
+    objectivesVm: ObjectivesViewModel
+) {
+  // Attendance modal (wired to VM state)
+  if (state.showAttendanceModal && state.selectedClass != null) {
+    val initial = state.attendanceRecords.firstOrNull { it.classId == state.selectedClass.id }
+    ClassAttendanceModal(
+        classItem = state.selectedClass,
+        initialAttendance = initial?.attendance,
+        initialCompletion = initial?.completion,
+        onDismiss = { vm.onDismissClassAttendanceModal() },
+        onSave = { attendance, completion ->
+          vm.saveClassAttendance(state.selectedClass, attendance, completion)
+        })
+  }
+
+  LazyColumn(
+      modifier = Modifier.fillMaxSize(),
+      verticalArrangement = Arrangement.spacedBy(16.dp),
+      contentPadding = PaddingValues(bottom = 96.dp) // leave room for FAB
+      ) {
+        item {
+          TodayCard(
+              classes = state.todayClasses,
+              attendance = state.attendanceRecords,
+              objectivesVm = objectivesVm,
+              onClassClick = { vm.onClassClicked(it) },
+              modifier = Modifier.fillMaxWidth())
+        }
+      }
+}
+
+/* ---------- UI building blocks ---------- */
+
+@Composable
+private fun TodayCard(
+    classes: List<Class>,
+    attendance: List<ClassAttendance>,
+    objectivesVm: ObjectivesViewModel,
+    onClassClick: (Class) -> Unit,
+    modifier: Modifier = Modifier
+) {
+  val cs = MaterialTheme.colorScheme
+  val today = LocalDate.now()
+  val dateText = DateTimeFormatter.ofPattern("EEEE, MMM d").format(today)
+
+  GlassSurface(modifier.fillMaxWidth(), shape = RoundedCornerShape(20.dp)) {
+    // Header
+    Text(
+        text = stringResource(R.string.today_title_fmt, dateText),
+        style =
+            MaterialTheme.typography.titleMedium.copy(
+                fontWeight = FontWeight.Bold, fontSize = 20.sp, color = cs.onSurface),
+        modifier = Modifier.padding(bottom = 6.dp))
+    Spacer(Modifier.height(12.dp))
+
+    // ---- Classes section (card inside card) ----
+    SectionBox(
+        header = {
+          Text(
+              stringResource(R.string.classes_label),
+              style =
+                  MaterialTheme.typography.titleMedium.copy(
+                      fontSize = 18.sp,
+                      fontWeight = FontWeight.SemiBold,
+                      color = MaterialTheme.colorScheme.onSurface),
+              modifier = Modifier.padding(bottom = 8.dp))
+        }) {
+          if (classes.isEmpty()) {
+            Text(stringResource(R.string.no_classes_today), color = cs.onSurface.copy(alpha = 0.7f))
+          } else {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+              classes.forEachIndexed { idx, c ->
+                val record = attendance.firstOrNull { it.classId == c.id }
+                CompactClassRow(
+                    clazz = c,
+                    record = record,
+                    modifier = Modifier.fillMaxWidth().clickable { onClassClick(c) })
+                if (idx != classes.lastIndex) {
+                  HorizontalDivider(color = cs.onSurface.copy(alpha = 0.08f))
+                }
+              }
+            }
+          }
+        }
+
+    Spacer(Modifier.height(14.dp))
+
+    // ---- Daily objectives (your existing composable already looks like the mock) ----
+    MaterialTheme(
+        colorScheme =
+            MaterialTheme.colorScheme.copy(
+                // ensure it uses your app purple for its internal Icons/Text tints
+                primary = PurplePrimary),
+        typography =
+            MaterialTheme.typography.copy(
+                // DailyObjectivesSection uses titleMedium; bump it here locally
+                titleMedium =
+                    MaterialTheme.typography.titleMedium.copy(
+                        fontSize = 18.sp, fontWeight = FontWeight.SemiBold))) {
+          DailyObjectivesSection(viewModel = objectivesVm, modifier = Modifier.fillMaxWidth())
+        }
+
+    Spacer(Modifier.height(14.dp))
+
+    // ---- Wellness (match Classes/DailyObjectives look) ----
+    SectionBox(
+        header = {
+          Text(
+              stringResource(R.string.wellness_events_label),
+              style =
+                  MaterialTheme.typography.titleMedium.copy(
+                      fontSize = 18.sp, fontWeight = FontWeight.SemiBold, color = cs.onSurface),
+              modifier = Modifier.padding(bottom = 8.dp))
+        }) {
+          Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            WellnessEventItem(
+                title = stringResource(R.string.wellness_event_yoga_title),
+                time = stringResource(R.string.wellness_event_yoga_time),
+                description = stringResource(R.string.wellness_event_yoga_description),
+                eventType = WellnessEventType.YOGA,
+                onClick = {})
+            HorizontalDivider(color = cs.onSurface.copy(alpha = 0.08f))
+            WellnessEventItem(
+                title = stringResource(R.string.wellness_event_lecture_title),
+                time = stringResource(R.string.wellness_event_lecture_time),
+                description = stringResource(R.string.wellness_event_lecture_description),
+                eventType = WellnessEventType.LECTURE,
+                onClick = {})
+          }
+        }
+  }
+}
+
+/** Sub-card with rounded border (looks like the inner rounded section in your mock) */
+@Composable
+private fun SectionBox(
+    title: String? = null,
+    header: (@Composable () -> Unit)? = null,
+    content: @Composable ColumnScope.() -> Unit
+) {
+  val cs = MaterialTheme.colorScheme
+  GlassSurface(shape = RoundedCornerShape(16.dp)) {
+    when {
+      header != null -> header()
+      title != null ->
+          Text(
+              title,
+              style =
+                  MaterialTheme.typography.titleMedium.copy(
+                      fontSize = 18.sp, fontWeight = FontWeight.SemiBold, color = cs.onSurface),
+              modifier = Modifier.padding(bottom = 8.dp))
+    }
+    Column(content = content)
+  }
+}
+
+@Composable
+private fun CompactClassRow(clazz: Class, record: ClassAttendance?, modifier: Modifier = Modifier) {
+  val cs = MaterialTheme.colorScheme
+  val (iconRes, badgeColor) =
+      when (clazz.type) {
+        ClassType.LECTURE -> R.drawable.ic_lecture to LightBlueAccent
+        ClassType.EXERCISE -> R.drawable.ic_exercise to CustomGreen
+        ClassType.LAB -> R.drawable.ic_lab to AccentViolet
+      }
+  val typeLabel =
+      when (clazz.type) {
+        ClassType.LECTURE -> stringResource(R.string.lecture_type)
+        ClassType.EXERCISE -> stringResource(R.string.exercise_type)
+        ClassType.LAB -> stringResource(R.string.lab_type)
+      }
+  val timeFmt = DateTimeFormatter.ofPattern("HH:mm")
+
+  Row(modifier, verticalAlignment = Alignment.CenterVertically) {
+    Box(
+        modifier =
+            Modifier.size(36.dp)
+                .clip(RoundedCornerShape(10.dp))
+                .background(badgeColor.copy(alpha = .16f)) // subtle filled badge
+                .border(1.dp, badgeColor.copy(alpha = .32f), RoundedCornerShape(10.dp)),
+        contentAlignment = Alignment.Center) {
+          Icon(painterResource(iconRes), null, tint = badgeColor, modifier = Modifier.size(20.dp))
+        }
+
+    Spacer(Modifier.width(10.dp))
+
+    Column(Modifier.weight(1f)) {
+      Text(
+          "${clazz.courseName} ($typeLabel)",
+          color = cs.onSurface,
+          fontWeight = FontWeight.SemiBold,
+          fontSize = 16.sp)
+      Text("(${typeLabel})", color = cs.onSurface.copy(alpha = 0.65f), fontSize = 12.sp)
+      Spacer(Modifier.height(2.dp))
+      Text(
+          "${clazz.startTime.format(timeFmt)} - ${clazz.endTime.format(timeFmt)}",
+          color = cs.onSurface.copy(alpha = 0.75f),
+          fontSize = 12.sp)
+      Text(
+          "${clazz.location} • ${clazz.instructor}",
+          color = cs.onSurface.copy(alpha = 0.65f),
+          fontSize = 12.sp)
+    }
+
+    Spacer(Modifier.width(10.dp))
+
+    if (record != null) {
+      Column(
+          horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            // Attendance
+            val attColor =
+                when (record.attendance) {
+                  AttendanceStatus.YES -> CustomGreen
+                  AttendanceStatus.ARRIVED_LATE -> StatBarLightbulb
+                  AttendanceStatus.NO -> Pink
+                }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+              Icon(
+                  painterResource(R.drawable.ic_check_circle),
+                  null,
+                  tint = attColor,
+                  modifier = Modifier.size(16.dp))
+              Spacer(Modifier.width(6.dp))
+              Text(
+                  text =
+                      when (record.attendance) {
+                        AttendanceStatus.YES -> stringResource(R.string.attendance_attended)
+                        AttendanceStatus.ARRIVED_LATE ->
+                            stringResource(R.string.attendance_arrived_late)
+                        AttendanceStatus.NO -> stringResource(R.string.attendance_missed)
+                      },
+                  color = attColor,
+                  fontSize = 12.sp,
+                  fontWeight = FontWeight.Medium)
+            }
+            // Completion
+            val compColor =
+                when (record.completion) {
+                  CompletionStatus.YES -> PurplePrimary
+                  CompletionStatus.PARTIALLY -> StatBarLightbulb
+                  CompletionStatus.NO -> Pink
+                }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+              Icon(
+                  painterResource(R.drawable.ic_done_all),
+                  null,
+                  tint = compColor,
+                  modifier = Modifier.size(16.dp))
+              Spacer(Modifier.width(6.dp))
+              Text(
+                  text =
+                      when (record.completion) {
+                        CompletionStatus.YES -> stringResource(R.string.completion_done)
+                        CompletionStatus.PARTIALLY -> stringResource(R.string.completion_partially)
+                        CompletionStatus.NO -> stringResource(R.string.completion_not_done)
+                      },
+                  color = compColor,
+                  fontSize = 12.sp,
+                  fontWeight = FontWeight.Medium)
+            }
+          }
+    }
+  }
+}

--- a/app/src/main/java/com/android/sample/ui/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/schedule/ScheduleScreen.kt
@@ -1,0 +1,194 @@
+package com.android.sample.ui.schedule
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.android.sample.R
+import com.android.sample.feature.schedule.data.calendar.StudyItem
+import com.android.sample.feature.schedule.data.schedule.EventKind
+import com.android.sample.feature.schedule.data.schedule.Priority
+import com.android.sample.feature.schedule.data.schedule.ScheduleEvent
+import com.android.sample.feature.schedule.data.schedule.ScheduleTab
+import com.android.sample.feature.schedule.data.schedule.SourceTag
+import com.android.sample.feature.schedule.repository.calendar.CalendarRepositoryImpl // tasks repo
+import com.android.sample.feature.schedule.repository.planner.FakePlannerRepository // classes+attendance repo
+import com.android.sample.feature.schedule.repository.schedule.ScheduleRepositoryImpl
+import com.android.sample.feature.schedule.repository.schedule.StudyItemMapper
+import com.android.sample.feature.schedule.viewmodel.ScheduleViewModel
+import com.android.sample.feature.weeks.viewmodel.ObjectivesViewModel
+import com.android.sample.feature.weeks.viewmodel.WeeksViewModel
+import com.android.sample.ui.planner.AddStudyTaskModal
+import com.android.sample.ui.planner.PetHeader
+import com.android.sample.ui.theme.BackgroundDark
+import com.android.sample.ui.theme.BackgroundGradientEnd
+import com.android.sample.ui.theme.PurplePrimary
+import java.time.LocalDate
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ScheduleScreen() {
+  // Repos
+  val taskRepo = remember { CalendarRepositoryImpl() } // tasks
+  val plannerRepo = remember { FakePlannerRepository() } // classes & attendance
+  val resources = LocalContext.current.resources
+
+  // Schedule repository now needs Resources
+  val scheduleRepo = remember { ScheduleRepositoryImpl(taskRepo, plannerRepo, resources) }
+
+  val vm: ScheduleViewModel =
+      viewModel(
+          key = "ScheduleVM",
+          factory =
+              object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                  return ScheduleViewModel(
+                      scheduleRepository = scheduleRepo,
+                      plannerRepository = plannerRepo,
+                      resources = resources)
+                      as T
+                }
+              })
+
+  val objectivesVm: ObjectivesViewModel = viewModel()
+  val weeksVm: WeeksViewModel = viewModel()
+
+  val state by vm.uiState.collectAsState()
+  val allTasks: List<StudyItem> =
+      remember(state.allEvents) {
+        state.allEvents.map { StudyItemMapper.fromScheduleEvent(it, resources) }
+      }
+
+  var currentTab by remember { mutableStateOf(ScheduleTab.DAY) }
+  var showAddModal by remember { mutableStateOf(false) }
+  var addDate by remember { mutableStateOf<LocalDate?>(null) }
+
+  // Snackbar for VM events
+  val snackbarHostState = remember { SnackbarHostState() }
+  LaunchedEffect(Unit) {
+    vm.eventFlow.collect { e ->
+      when (e) {
+        is ScheduleViewModel.UiEvent.ShowSnackbar -> snackbarHostState.showSnackbar(e.message)
+      }
+    }
+  }
+
+  // Keep VM mode in sync with tab
+  LaunchedEffect(currentTab) {
+    when (currentTab) {
+      ScheduleTab.WEEK -> {
+        vm.setWeekMode()
+        if (!state.isAdjustingPlan) vm.adjustWeeklyPlan()
+      }
+      ScheduleTab.MONTH -> vm.setMonthMode()
+      else -> Unit
+    }
+  }
+
+  Scaffold(
+      snackbarHost = { SnackbarHost(snackbarHostState) },
+      floatingActionButton = {
+        FloatingActionButton(
+            onClick = {
+              addDate =
+                  when (currentTab) {
+                    ScheduleTab.DAY -> LocalDate.now()
+                    ScheduleTab.WEEK -> vm.startOfWeek(state.selectedDate)
+                    ScheduleTab.MONTH,
+                    ScheduleTab.AGENDA -> state.selectedDate
+                  }
+              showAddModal = true
+            },
+            containerColor = PurplePrimary,
+            contentColor = Color.White) {
+              Icon(Icons.Filled.Add, contentDescription = stringResource(R.string.add_event))
+            }
+      },
+      containerColor = Color.Transparent,
+      modifier =
+          Modifier.background(
+              Brush.verticalGradient(listOf(BackgroundDark, BackgroundGradientEnd)))) { padding ->
+        Column(
+            modifier =
+                Modifier.fillMaxSize()
+                    .padding(padding)
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally) {
+              // Header now matches Home (use the updated PetHeader you implemented)
+              PetHeader(level = 5)
+
+              Spacer(Modifier.height(8.dp))
+
+              // ThemedTabRow will now use the GlassSurface background and adjusted styling
+              ThemedTabRow(
+                  selected = currentTab.ordinal,
+                  onSelected = { currentTab = ScheduleTab.values()[it] },
+                  labels =
+                      listOf(
+                          stringResource(R.string.tab_day),
+                          stringResource(R.string.tab_week),
+                          stringResource(R.string.tab_month),
+                          stringResource(R.string.tab_agenda)))
+
+              Spacer(Modifier.height(8.dp))
+              if (state.isAdjustingPlan) {
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth().height(4.dp))
+                Spacer(Modifier.height(8.dp))
+              }
+
+              when (currentTab) {
+                ScheduleTab.DAY ->
+                    DayTabContent(vm = vm, state = state, objectivesVm = objectivesVm)
+                ScheduleTab.WEEK -> {
+                  // TODO: implement Week
+                }
+                ScheduleTab.MONTH -> {
+                  // TODO: implement Month
+                }
+                ScheduleTab.AGENDA -> {
+                  // TODO: implement Agenda
+                }
+              }
+            }
+      }
+
+  if (showAddModal && addDate != null) {
+    AddStudyTaskModal(
+        onDismiss = {
+          showAddModal = false
+          addDate = null
+        },
+        onAddTask = { subject, title, duration, _, priority ->
+          val event =
+              ScheduleEvent(
+                  title = if (title.isNotBlank()) title else subject,
+                  date = addDate!!,
+                  time = null,
+                  durationMinutes = duration,
+                  kind = EventKind.STUDY,
+                  priority =
+                      when (priority.lowercase()) {
+                        "low" -> Priority.LOW
+                        "high" -> Priority.HIGH
+                        else -> Priority.MEDIUM
+                      },
+                  sourceTag = SourceTag.Task)
+          vm.save(event)
+          showAddModal = false
+          addDate = null
+        })
+  }
+}

--- a/app/src/main/java/com/android/sample/ui/schedule/Sections.kt
+++ b/app/src/main/java/com/android/sample/ui/schedule/Sections.kt
@@ -1,0 +1,109 @@
+package com.android.sample.ui.schedule
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+private fun GlassSurfaceCompact(
+    modifier: Modifier = Modifier,
+    shape: RoundedCornerShape = RoundedCornerShape(18.dp),
+    content: @Composable ColumnScope.() -> Unit
+) {
+  val cs = MaterialTheme.colorScheme
+  val gradient =
+      Brush.linearGradient(
+          listOf(cs.surfaceVariant.copy(alpha = 0.20f), cs.surfaceVariant.copy(alpha = 0.10f)))
+  Surface(color = Color.Transparent, shape = shape) {
+    Column(
+        Modifier.clip(shape)
+            .background(gradient)
+            .border(1.dp, cs.onSurface.copy(alpha = 0.12f), shape)
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        content = content)
+  }
+}
+
+@Composable
+fun ThemedTabRow(selected: Int, onSelected: (Int) -> Unit, labels: List<String>) {
+  val cs = MaterialTheme.colorScheme
+  val chipShape = RoundedCornerShape(14.dp)
+  val density = LocalDensity.current
+
+  GlassSurfaceCompact(modifier = Modifier.fillMaxWidth(), shape = RoundedCornerShape(20.dp)) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically) {
+          labels.forEachIndexed { i, label ->
+            val isSelected = i == selected
+            var textPxWidth by remember { mutableStateOf(0) }
+
+            Surface(
+                onClick = { onSelected(i) },
+                shape = chipShape,
+                color = if (isSelected) cs.primary else Color.Transparent,
+                modifier = Modifier.height(36.dp), // denser
+                tonalElevation = if (isSelected) 2.dp else 0.dp) {
+                  Box(
+                      modifier =
+                          Modifier.fillMaxHeight().padding(horizontal = 16.dp), // chip padding
+                      contentAlignment = Alignment.CenterStart) {
+                        // Use BasicText (or Text) with onTextLayout PARAMETER
+                        androidx.compose.foundation.text.BasicText(
+                            text = label,
+                            style =
+                                androidx.compose.ui.text.TextStyle(
+                                    fontSize = 16.sp, // a bit bigger
+                                    fontWeight = FontWeight.SemiBold,
+                                    color =
+                                        if (isSelected) cs.onPrimary
+                                        else cs.onSurface.copy(alpha = 0.85f),
+                                    textAlign = androidx.compose.ui.text.style.TextAlign.Start),
+                            onTextLayout = { layoutResult ->
+                              textPxWidth = layoutResult.size.width
+                            })
+
+                        if (isSelected && textPxWidth > 0) {
+                          val underlineWidth = with(density) { textPxWidth.toDp() }
+                          Box(
+                              modifier =
+                                  Modifier.align(Alignment.BottomStart)
+                                      .padding(bottom = 5.dp) // lift from bottom
+                                      .height(3.dp)
+                                      .width(underlineWidth) // exactly under the word
+                                      .clip(RoundedCornerShape(50))
+                                      .background(Color.White.copy(alpha = 0.96f)))
+                        }
+                      }
+                }
+          }
+        }
+  }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,4 +185,33 @@
     <string name="class_description_fmt">%1$s %2$s %3$s %4$s %5$s</string>
     <string name="keyword_at">at</string>
 
+    <!-- Tabs -->
+    <string name="tab_day">Day</string>
+    <string name="tab_week">Week</string>
+    <string name="tab_month">Month</string>
+    <string name="tab_agenda">Agenda</string>
+
+    <!-- Today card -->
+    <string name="today_title_fmt">Today • %1$s</string>
+    <string name="classes_label">Classes</string>
+    <string name="no_classes_today">No classes scheduled today</string>
+    <string name="wellness_events_label">Wellness Events</string>
+
+    <!-- Class row -->
+    <string name="class_title_fmt">%1$s (%2$s)</string>
+    <string name="class_type_paren">(%1$s)</string>
+    <string name="class_time_range_fmt">%1$s - %2$s</string>
+    <string name="class_location_prof_fmt">%1$s • %2$s</string>
+
+    <!-- Attendance labels -->
+    <string name="attendance_attended">Attended</string>
+    <string name="attendance_arrived_late">Arrived late</string>
+    <string name="attendance_missed">Missed</string>
+
+    <!-- Completion labels -->
+    <string name="completion_done">Completed</string>
+    <string name="completion_partially">Partially</string>
+    <string name="completion_not_done">Not done</string>
+
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="did_you_review_lecture">Did you finish reviewing today’s lecture materials?</string>
     <string name="did_you_finish_exercise">Did you finish the exercise?</string>
     <string name="did_you_finish_lab">Did you finish the lab?</string>
+    <string name="cancel">Cancel</string>
 
     <!-- Wellness Event Item -->
     <string name="wellness_event_yoga_title">Yoga Session @ Sports Center</string>

--- a/app/src/test/java/com/android/sample/planner/ModelClassesTest.kt
+++ b/app/src/test/java/com/android/sample/planner/ModelClassesTest.kt
@@ -1,6 +1,10 @@
 package com.android.sample.planner
 
-import com.android.sample.model.planner.*
+import com.android.sample.feature.schedule.data.planner.AttendanceStatus
+import com.android.sample.feature.schedule.data.planner.Class
+import com.android.sample.feature.schedule.data.planner.ClassAttendance
+import com.android.sample.feature.schedule.data.planner.ClassType
+import com.android.sample.feature.schedule.data.planner.CompletionStatus
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime

--- a/app/src/test/java/com/android/sample/planner/PlannerDataTest.kt
+++ b/app/src/test/java/com/android/sample/planner/PlannerDataTest.kt
@@ -1,6 +1,10 @@
 package com.android.sample.planner
 
-import com.android.sample.model.planner.*
+import com.android.sample.feature.schedule.data.planner.AttendanceStatus
+import com.android.sample.feature.schedule.data.planner.Class
+import com.android.sample.feature.schedule.data.planner.ClassAttendance
+import com.android.sample.feature.schedule.data.planner.ClassType
+import com.android.sample.feature.schedule.data.planner.CompletionStatus
 import java.time.LocalDate
 import java.time.LocalTime
 import org.junit.Assert.*

--- a/app/src/test/java/com/android/sample/planner/PlannerRepositoryExtraTest.kt
+++ b/app/src/test/java/com/android/sample/planner/PlannerRepositoryExtraTest.kt
@@ -1,6 +1,6 @@
 package com.android.sample.planner
 
-import com.android.sample.model.planner.*
+import com.android.sample.feature.schedule.repository.planner.PlannerRepository
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*

--- a/app/src/test/java/com/android/sample/planner/PlannerRepositoryTest.kt
+++ b/app/src/test/java/com/android/sample/planner/PlannerRepositoryTest.kt
@@ -1,6 +1,9 @@
 package com.android.sample.planner
 
-import com.android.sample.model.planner.*
+import com.android.sample.feature.schedule.data.planner.AttendanceStatus
+import com.android.sample.feature.schedule.data.planner.ClassAttendance
+import com.android.sample.feature.schedule.data.planner.CompletionStatus
+import com.android.sample.feature.schedule.repository.planner.PlannerRepository
 import java.time.LocalDate
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first

--- a/app/src/test/java/com/android/sample/planner/PlannerViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/planner/PlannerViewModelTest.kt
@@ -4,9 +4,15 @@ import androidx.lifecycle.viewModelScope
 import com.android.sample.data.Priority
 import com.android.sample.data.Status
 import com.android.sample.data.ToDo
-import com.android.sample.model.planner.*
+import com.android.sample.feature.schedule.data.planner.AttendanceStatus
+import com.android.sample.feature.schedule.data.planner.Class
+import com.android.sample.feature.schedule.data.planner.ClassAttendance
+import com.android.sample.feature.schedule.data.planner.ClassType
+import com.android.sample.feature.schedule.data.planner.CompletionStatus
+import com.android.sample.feature.schedule.repository.planner.PlannerRepository
+import com.android.sample.feature.schedule.viewmodel.PlannerViewModel
 import com.android.sample.repositories.ToDoRepositoryLocal
-import com.android.sample.ui.viewmodel.PlannerViewModel
+import java.time.LocalDate
 import java.time.LocalTime
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.first
@@ -236,11 +242,11 @@ class PlannerViewModelTest {
                             listOf(
                                 ToDo(
                                     title = "Finish report",
-                                    dueDate = java.time.LocalDate.now(),
+                                    dueDate = LocalDate.now(),
                                     priority = Priority.HIGH),
                                 ToDo(
                                     title = "Read chapter",
-                                    dueDate = java.time.LocalDate.now().plusDays(1),
+                                    dueDate = LocalDate.now().plusDays(1),
                                     priority = Priority.MEDIUM))))
 
         // Let collectors run (UnconfinedTestDispatcher -> small delay is fine)

--- a/app/src/test/java/com/android/sample/screen/calendar/PlannerRepositoryImplTest.kt
+++ b/app/src/test/java/com/android/sample/screen/calendar/PlannerRepositoryImplTest.kt
@@ -1,9 +1,9 @@
 package com.android.sample.screen.calendar
 
-import com.android.sample.model.PlannerRepository
-import com.android.sample.model.PlannerRepositoryImpl
-import com.android.sample.model.StudyItem
-import com.android.sample.model.TaskType
+import com.android.sample.feature.schedule.data.calendar.StudyItem
+import com.android.sample.feature.schedule.data.calendar.TaskType
+import com.android.sample.feature.schedule.repository.calendar.CalendarRepository
+import com.android.sample.feature.schedule.repository.calendar.CalendarRepositoryImpl
 import java.time.LocalDate
 import java.time.LocalTime
 import kotlinx.coroutines.runBlocking
@@ -14,7 +14,7 @@ class PlannerRepositoryImplTest {
 
   @Test
   fun save_get_update_delete_flow() = runBlocking {
-    val repo: PlannerRepository = PlannerRepositoryImpl() // pre-seeded
+    val repo: CalendarRepository = CalendarRepositoryImpl() // pre-seeded
     val d = LocalDate.now()
 
     val item =
@@ -44,7 +44,7 @@ class PlannerRepositoryImplTest {
 
   @Test
   fun getAllTasksReflectsMutations() = runBlocking {
-    val repo: PlannerRepository = PlannerRepositoryImpl()
+    val repo: CalendarRepository = CalendarRepositoryImpl()
     val initial = repo.getAllTasks().size
 
     val newItem =

--- a/app/src/test/java/com/android/sample/screen/calendar/StudyItemTest.kt
+++ b/app/src/test/java/com/android/sample/screen/calendar/StudyItemTest.kt
@@ -1,10 +1,13 @@
 package com.android.sample.screen.calendar
 
-import com.android.sample.model.Priority
-import com.android.sample.model.StudyItem
-import com.android.sample.model.TaskType
+import com.android.sample.feature.schedule.data.calendar.CalendarUiState
+import com.android.sample.feature.schedule.data.calendar.Priority
+import com.android.sample.feature.schedule.data.calendar.StudyItem
+import com.android.sample.feature.schedule.data.calendar.TaskType
 import java.time.LocalDate
-import junit.framework.TestCase.assertEquals
+import java.time.LocalTime
+import java.time.YearMonth
+import org.junit.Assert.*
 import org.junit.Test
 
 class StudyItemTest {
@@ -23,9 +26,192 @@ class StudyItemTest {
             type = TaskType.STUDY)
     val changed = base.copy(title = "New", isCompleted = true)
     assertEquals("New", changed.title)
-    assertEquals(true, changed.isCompleted)
+    assertTrue(changed.isCompleted)
     assertEquals(60, changed.durationMinutes)
     assertEquals(d, changed.date)
     assertEquals(TaskType.STUDY, changed.type)
+  }
+
+  @Test
+  fun default_values_are_set_and_uuid_is_generated() {
+    val d = LocalDate.of(2025, 1, 2)
+    val item =
+        StudyItem(
+            title = "Untimed",
+            date = d,
+            type = TaskType.WORK // leave description/time/duration at defaults
+            )
+
+    // id should be a non-empty random UUID
+    assertTrue(item.id.isNotBlank())
+    assertNull(item.description)
+    assertNull(item.time)
+    assertNull(item.durationMinutes)
+    assertEquals(false, item.isCompleted)
+    assertEquals(Priority.MEDIUM, item.priority)
+    assertEquals(TaskType.WORK, item.type)
+    assertEquals(d, item.date)
+  }
+
+  @Test
+  fun uuid_is_unique_across_instances() {
+    val d = LocalDate.of(2025, 1, 2)
+    val items = (0 until 10).map { StudyItem(title = "t$it", date = d, type = TaskType.PERSONAL) }
+    val distinctIds = items.map { it.id }.toSet()
+    assertEquals(items.size, distinctIds.size)
+  }
+
+  @Test
+  fun time_and_duration_are_preserved_through_copy() {
+    val d = LocalDate.of(2025, 3, 4)
+    val t = LocalTime.of(9, 30)
+    val base =
+        StudyItem(
+            title = "Timed",
+            date = d,
+            time = t,
+            durationMinutes = 45,
+            type = TaskType.STUDY,
+            priority = Priority.HIGH)
+    val changed = base.copy(priority = Priority.LOW)
+
+    assertEquals(t, changed.time)
+    assertEquals(45, changed.durationMinutes)
+    assertEquals(Priority.LOW, changed.priority)
+    // ensure other fields unchanged
+    assertEquals(d, changed.date)
+    assertEquals("Timed", changed.title)
+  }
+
+  @Test
+  fun equals_and_hashCode_match_on_all_fields_except_id_when_equal() {
+    val d = LocalDate.of(2025, 5, 6)
+    val t = LocalTime.of(14, 0)
+    // same id -> equal
+    val id = "fixed-id"
+    val a =
+        StudyItem(
+            id = id,
+            title = "Same",
+            description = "D",
+            date = d,
+            time = t,
+            durationMinutes = 30,
+            isCompleted = true,
+            priority = Priority.HIGH,
+            type = TaskType.WORK)
+    val b =
+        StudyItem(
+            id = id,
+            title = "Same",
+            description = "D",
+            date = d,
+            time = t,
+            durationMinutes = 30,
+            isCompleted = true,
+            priority = Priority.HIGH,
+            type = TaskType.WORK)
+
+    assertEquals(a, b)
+    assertEquals(a.hashCode(), b.hashCode())
+  }
+
+  @Test
+  fun not_equal_when_ids_differ_even_if_other_fields_match() {
+    val d = LocalDate.of(2025, 5, 6)
+    val t = LocalTime.of(14, 0)
+    val a =
+        StudyItem(
+            id = "A",
+            title = "Same",
+            description = "D",
+            date = d,
+            time = t,
+            durationMinutes = 30,
+            isCompleted = true,
+            priority = Priority.HIGH,
+            type = TaskType.WORK)
+    val b =
+        StudyItem(
+            id = "B",
+            title = "Same",
+            description = "D",
+            date = d,
+            time = t,
+            durationMinutes = 30,
+            isCompleted = true,
+            priority = Priority.HIGH,
+            type = TaskType.WORK)
+
+    assertNotEquals(a, b)
+  }
+
+  // ---------- CalendarUiState coverage ----------
+
+  @Test
+  fun calendarUiState_defaults_are_sensible() {
+    val s = CalendarUiState()
+    // Defaults
+    assertTrue(s.tasksByDate.isEmpty())
+    assertTrue(s.isMonthView)
+    assertFalse(s.isShowingAddEditModal)
+    assertNull(s.taskToEdit)
+    // selectedDate/currentDisplayMonth default to "now" — assert they are consistent
+    assertEquals(YearMonth.from(s.selectedDate), s.currentDisplayMonth)
+  }
+
+  @Test
+  fun calendarUiState_custom_values_are_preserved() {
+    val d1 = LocalDate.of(2025, 2, 10)
+    val d2 = LocalDate.of(2025, 2, 11)
+    val item1 = StudyItem(title = "A", date = d1, type = TaskType.STUDY)
+    val item2 = StudyItem(title = "B", date = d2, type = TaskType.WORK)
+    val map = mapOf(d1 to listOf(item1), d2 to listOf(item2))
+    val ym = YearMonth.of(2025, 2)
+    val s =
+        CalendarUiState(
+            tasksByDate = map,
+            selectedDate = d1,
+            currentDisplayMonth = ym,
+            isMonthView = false,
+            isShowingAddEditModal = true,
+            taskToEdit = item2)
+
+    assertEquals(map, s.tasksByDate)
+    assertEquals(d1, s.selectedDate)
+    assertEquals(ym, s.currentDisplayMonth)
+    assertFalse(s.isMonthView)
+    assertTrue(s.isShowingAddEditModal)
+    assertEquals(item2, s.taskToEdit)
+  }
+
+  @Test
+  fun calendarUiState_copy_toggles_modal_and_selection() {
+    val d = LocalDate.of(2025, 7, 20)
+    val i = StudyItem(title = "Edit me", date = d, type = TaskType.PERSONAL)
+    val s = CalendarUiState(selectedDate = d, isShowingAddEditModal = false, taskToEdit = null)
+
+    val s2 = s.copy(isShowingAddEditModal = true, taskToEdit = i)
+    assertTrue(s2.isShowingAddEditModal)
+    assertEquals(i, s2.taskToEdit)
+
+    val nextMonth = s2.currentDisplayMonth.plusMonths(1)
+    val s3 = s2.copy(currentDisplayMonth = nextMonth, isMonthView = true)
+    assertEquals(nextMonth, s3.currentDisplayMonth)
+    assertTrue(s3.isMonthView)
+  }
+
+  // ---------- Sorting / grouping sanity (hits more StudyItem fields) ----------
+
+  @Test
+  fun tasks_can_be_sorted_by_date_then_time_nulls_last() {
+    val d = LocalDate.of(2025, 9, 1)
+    val a = StudyItem(title = "A", date = d, time = LocalTime.of(8, 0), type = TaskType.STUDY)
+    val b = StudyItem(title = "B", date = d, time = LocalTime.of(7, 30), type = TaskType.STUDY)
+    val c = StudyItem(title = "C", date = d, time = null, type = TaskType.STUDY)
+    val list =
+        listOf(a, b, c)
+            .sortedWith(compareBy<StudyItem> { it.date }.thenBy { it.time ?: LocalTime.MAX })
+    assertEquals(listOf(b, a, c).map { it.title }, list.map { it.title })
   }
 }

--- a/app/src/test/java/com/android/sample/ui/schedule/AdaptivePlannerTest.kt
+++ b/app/src/test/java/com/android/sample/ui/schedule/AdaptivePlannerTest.kt
@@ -1,6 +1,9 @@
 package com.android.sample.ui.schedule
 
-import com.android.sample.model.schedule.*
+import com.android.sample.feature.schedule.data.schedule.EventKind
+import com.android.sample.feature.schedule.data.schedule.Priority
+import com.android.sample.feature.schedule.data.schedule.ScheduleEvent
+import com.android.sample.feature.schedule.data.schedule.SourceTag
 import java.time.LocalDate
 import java.time.LocalTime
 import org.junit.Assert.*

--- a/app/src/test/java/com/android/sample/ui/schedule/ClassMapperTest.kt
+++ b/app/src/test/java/com/android/sample/ui/schedule/ClassMapperTest.kt
@@ -3,12 +3,12 @@ package com.android.sample.ui.schedule
 import android.content.res.Resources
 import androidx.test.core.app.ApplicationProvider
 import com.android.sample.R
-import com.android.sample.model.planner.Class as PlannerClass
-import com.android.sample.model.planner.ClassType
-import com.android.sample.model.schedule.ClassMapper
-import com.android.sample.model.schedule.EventKind
-import com.android.sample.model.schedule.ScheduleEvent
-import com.android.sample.model.schedule.SourceTag
+import com.android.sample.feature.schedule.data.planner.Class as PlannerClass
+import com.android.sample.feature.schedule.data.planner.ClassType
+import com.android.sample.feature.schedule.data.schedule.EventKind
+import com.android.sample.feature.schedule.data.schedule.ScheduleEvent
+import com.android.sample.feature.schedule.data.schedule.SourceTag
+import com.android.sample.feature.schedule.repository.schedule.ClassMapper
 import java.time.LocalDate
 import java.time.LocalTime
 import org.junit.Assert.*

--- a/app/src/test/java/com/android/sample/ui/schedule/ScheduleEventHelpersTest.kt
+++ b/app/src/test/java/com/android/sample/ui/schedule/ScheduleEventHelpersTest.kt
@@ -1,6 +1,8 @@
 package com.android.sample.ui.schedule
 
-import com.android.sample.model.schedule.*
+import com.android.sample.feature.schedule.data.schedule.EventKind
+import com.android.sample.feature.schedule.data.schedule.ScheduleEvent
+import com.android.sample.feature.schedule.data.schedule.SourceTag
 import java.time.LocalDate
 import java.time.LocalTime
 import org.junit.Assert.*

--- a/app/src/test/java/com/android/sample/ui/schedule/ScheduleRepositoryImplTest.kt
+++ b/app/src/test/java/com/android/sample/ui/schedule/ScheduleRepositoryImplTest.kt
@@ -1,15 +1,16 @@
 package com.android.sample.ui.schedule
 
+// fake
 import android.content.res.Resources
 import androidx.test.core.app.ApplicationProvider
-import com.android.sample.model.PlannerRepository // TASKS interface
-import com.android.sample.model.StudyItem
-import com.android.sample.model.TaskType
-import com.android.sample.model.planner.FakePlannerRepository // your CLASSES fake
-import com.android.sample.model.schedule.EventKind
-import com.android.sample.model.schedule.ScheduleEvent
-import com.android.sample.model.schedule.ScheduleRepositoryImpl
-import com.android.sample.model.schedule.SourceTag
+import com.android.sample.feature.schedule.data.calendar.StudyItem
+import com.android.sample.feature.schedule.data.calendar.TaskType
+import com.android.sample.feature.schedule.data.schedule.EventKind
+import com.android.sample.feature.schedule.data.schedule.ScheduleEvent
+import com.android.sample.feature.schedule.data.schedule.SourceTag
+import com.android.sample.feature.schedule.repository.calendar.CalendarRepository
+import com.android.sample.feature.schedule.repository.planner.FakePlannerRepository // your CLASSES
+import com.android.sample.feature.schedule.repository.schedule.ScheduleRepositoryImpl
 import java.time.LocalDate
 import java.time.LocalTime
 import kotlinx.coroutines.Dispatchers
@@ -123,7 +124,7 @@ class ScheduleRepositoryImplTest {
       }
 
   // ---------------- TASKS fake (implements com.android.sample.model.PlannerRepository)
-  private class FakeTasksRepo : PlannerRepository {
+  private class FakeTasksRepo : CalendarRepository {
     private val _tasks = MutableStateFlow<List<StudyItem>>(emptyList())
     override val tasksFlow: StateFlow<List<StudyItem>> = _tasks
 

--- a/app/src/test/java/com/android/sample/ui/schedule/ScheduleViewModelMoreBranchesTest.kt
+++ b/app/src/test/java/com/android/sample/ui/schedule/ScheduleViewModelMoreBranchesTest.kt
@@ -2,8 +2,13 @@ package com.android.sample.ui.schedule
 
 import android.content.res.Resources
 import androidx.test.core.app.ApplicationProvider
-import com.android.sample.model.planner.*
-import com.android.sample.model.schedule.*
+import com.android.sample.feature.schedule.data.planner.Class
+import com.android.sample.feature.schedule.data.planner.ClassAttendance
+import com.android.sample.feature.schedule.data.planner.ClassType
+import com.android.sample.feature.schedule.data.schedule.ScheduleEvent
+import com.android.sample.feature.schedule.repository.planner.PlannerRepository
+import com.android.sample.feature.schedule.repository.schedule.ScheduleRepository
+import com.android.sample.feature.schedule.viewmodel.ScheduleViewModel
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalTime

--- a/app/src/test/java/com/android/sample/ui/schedule/ScheduleViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/ui/schedule/ScheduleViewModelTest.kt
@@ -2,15 +2,16 @@ package com.android.sample.ui.schedule
 
 import android.content.res.Resources
 import androidx.test.core.app.ApplicationProvider
-import com.android.sample.model.planner.AttendanceStatus
-import com.android.sample.model.planner.Class
-import com.android.sample.model.planner.CompletionStatus
-import com.android.sample.model.planner.FakePlannerRepository
-import com.android.sample.model.schedule.EventKind
-import com.android.sample.model.schedule.Priority
-import com.android.sample.model.schedule.ScheduleEvent
-import com.android.sample.model.schedule.ScheduleRepository
-import com.android.sample.model.schedule.SourceTag
+import com.android.sample.feature.schedule.data.planner.AttendanceStatus
+import com.android.sample.feature.schedule.data.planner.Class
+import com.android.sample.feature.schedule.data.planner.CompletionStatus
+import com.android.sample.feature.schedule.data.schedule.EventKind
+import com.android.sample.feature.schedule.data.schedule.Priority
+import com.android.sample.feature.schedule.data.schedule.ScheduleEvent
+import com.android.sample.feature.schedule.data.schedule.SourceTag
+import com.android.sample.feature.schedule.repository.planner.FakePlannerRepository
+import com.android.sample.feature.schedule.repository.schedule.ScheduleRepository
+import com.android.sample.feature.schedule.viewmodel.ScheduleViewModel
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.YearMonth

--- a/app/src/test/java/com/android/sample/ui/schedule/StudyItemMapperTest.kt
+++ b/app/src/test/java/com/android/sample/ui/schedule/StudyItemMapperTest.kt
@@ -2,14 +2,14 @@ package com.android.sample.ui.schedule
 
 import android.content.res.Resources
 import androidx.test.core.app.ApplicationProvider
-import com.android.sample.model.Priority as ModelPriority
-import com.android.sample.model.StudyItem
-import com.android.sample.model.TaskType
-import com.android.sample.model.schedule.EventKind
-import com.android.sample.model.schedule.Priority
-import com.android.sample.model.schedule.ScheduleEvent
-import com.android.sample.model.schedule.SourceTag
-import com.android.sample.model.schedule.StudyItemMapper
+import com.android.sample.feature.schedule.data.calendar.Priority as ModelPriority
+import com.android.sample.feature.schedule.data.calendar.StudyItem
+import com.android.sample.feature.schedule.data.calendar.TaskType
+import com.android.sample.feature.schedule.data.schedule.EventKind
+import com.android.sample.feature.schedule.data.schedule.Priority
+import com.android.sample.feature.schedule.data.schedule.ScheduleEvent
+import com.android.sample.feature.schedule.data.schedule.SourceTag
+import com.android.sample.feature.schedule.repository.schedule.StudyItemMapper
 import java.time.LocalDate
 import java.time.LocalTime
 import org.junit.Assert.*


### PR DESCRIPTION
## Summary:
This PR introduces the unified day view within the new Schedule module, merging planner and daily objectives into one cohesive UI.
It represents the first step in consolidating Edumon’s scheduling experience, ensuring all daily classes and objectives and wellness information is presented in a single, consistent screen.
## What’s in this PR:

New Day screen:
- DayTabContent.kt (main layout)
- Sections.kt (GlassSurface/SectionBox/FramedSection)
- ScheduleScreen.kt (tab container; showing Day tab in this PR)
- Attendance modal wiring in Day view (ClassAttendanceModal)
- Integrated DailyObjectivesSection and WellnessEventItem
- Modifed PetHeader to match homescreen

API changes:
- None. No new collections/fields/indexes. Pure UI + ViewModel wiring and repo relocation.

## Implementation Notes:
- Decision: deliver Day view first to validate structure and UX, defer Week/Month/Agenda to follow-up PRs.
- Consistency: adopted shared glass surfaces + spacing; unified typography via M3.
- Performance considerations: LazyColumn with stable keys; modal composed only when showAttendanceModal == true. Lightweight recomposition via state hoisting in VMs.

## Testing:
New Day view tests: modal visibility, status rendering, screen container, themed tabs.

## Screenshots:
<img width="364" height="752" alt="Capture d&#39;écran 2025-11-10 211334" src="https://github.com/user-attachments/assets/2f2592a9-5b38-4cca-b3e1-be2a1e6c12f0" />
<img width="356" height="733" alt="Capture d&#39;écran 2025-11-10 211356" src="https://github.com/user-attachments/assets/2ec2e409-8de0-4bac-b7a2-103ef5533ec1" />

## Checklist:
- [x] Day view renders classes with attendance/completion
- [x] Daily Objectives visible and interactive
- [x] Wellness events rendered with proper icon/tint
- [x] Attendance modal opens/saves via ScheduleViewModel
- [x]  All moved packages compile; providers updated
- [x]  New/updated tests pass locally

## Issue_reference:
Closes #124 
