### PR TITLE
feature(scheadule): Add monthView + tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@
 .cxx
 local.properties
 firestore-debug.log
+firebase-debug.log
 .firebaserc
 MainActivity.kt

--- a/app/src/androidTest/java/com/android/sample/schedule/MonthTabContentTest.kt
+++ b/app/src/androidTest/java/com/android/sample/schedule/MonthTabContentTest.kt
@@ -1,0 +1,231 @@
+package com.android.sample.schedule
+
+import android.content.Context
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import com.android.sample.R
+import com.android.sample.feature.schedule.data.calendar.Priority
+import com.android.sample.feature.schedule.data.calendar.StudyItem
+import com.android.sample.feature.schedule.data.calendar.TaskType
+import com.android.sample.feature.schedule.data.schedule.ScheduleEvent
+import com.android.sample.feature.schedule.repository.planner.FakePlannerRepository
+import com.android.sample.feature.schedule.repository.schedule.ScheduleRepository
+import com.android.sample.feature.schedule.viewmodel.ScheduleViewModel
+import com.android.sample.ui.calendar.CalendarScreenTestTags
+import com.android.sample.ui.schedule.MonthTabContent
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.YearMonth
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Instrumented tests for MonthTabContent.
+ *
+ * File: app/src/androidTest/java/com/android/sample/schedule/MonthTabContentAllAndroidTest.kt
+ */
+class MonthTabContentAllAndroidTest {
+
+  @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+  // ────────────────────── Fakes / helpers ──────────────────────
+
+  private class FakeScheduleRepository(initial: List<ScheduleEvent> = emptyList()) :
+      ScheduleRepository {
+
+    private val _events = MutableStateFlow(initial)
+    override val events: StateFlow<List<ScheduleEvent>> = _events
+
+    override suspend fun save(event: ScheduleEvent) {
+      _events.value = _events.value.filterNot { it.id == event.id } + event
+    }
+
+    override suspend fun update(event: ScheduleEvent) {
+      _events.value = _events.value.map { if (it.id == event.id) event else it }
+    }
+
+    override suspend fun delete(eventId: String) {
+      _events.value = _events.value.filterNot { it.id == eventId }
+    }
+
+    override suspend fun getEventsBetween(start: LocalDate, end: LocalDate): List<ScheduleEvent> =
+        _events.value.filter { it.date in start..end }
+
+    override suspend fun getById(id: String): ScheduleEvent? =
+        _events.value.firstOrNull { it.id == id }
+
+    override suspend fun moveEventDate(id: String, newDate: LocalDate): Boolean {
+      val ev = getById(id) ?: return false
+      _events.value = _events.value.map { if (it.id == id) ev.copy(date = newDate) else it }
+      return true
+    }
+
+    override suspend fun getEventsForDate(date: LocalDate): List<ScheduleEvent> =
+        _events.value.filter { it.date == date }
+
+    override suspend fun getEventsForWeek(startDate: LocalDate): List<ScheduleEvent> =
+        getEventsBetween(startDate, startDate.plusDays(6))
+  }
+
+  private fun buildScheduleVm(ctx: Context): ScheduleViewModel {
+    val scheduleRepo = FakeScheduleRepository()
+    val plannerRepo = FakePlannerRepository() // from main code, safe for tests
+    return ScheduleViewModel(
+        scheduleRepository = scheduleRepo,
+        plannerRepository = plannerRepo,
+        resources = ctx.resources)
+  }
+
+  private fun sampleMonthTasks(month: YearMonth): List<StudyItem> {
+    val mid = month.atDay(10)
+    val later = month.atDay(20)
+    val outside = month.plusMonths(1).atDay(5)
+
+    return listOf(
+        StudyItem(
+            id = "h1",
+            title = "Important exam",
+            date = mid,
+            time = LocalTime.of(10, 0),
+            type = TaskType.STUDY,
+            priority = Priority.HIGH),
+        StudyItem(
+            id = "h2",
+            title = "Major project deadline",
+            date = later,
+            time = LocalTime.of(17, 0),
+            type = TaskType.STUDY,
+            priority = Priority.HIGH),
+        StudyItem(
+            id = "m1",
+            title = "Normal homework",
+            date = mid.plusDays(1),
+            time = LocalTime.of(14, 0),
+            type = TaskType.STUDY,
+            priority = Priority.MEDIUM),
+        // HIGH but outside this month – should NOT appear in important section
+        StudyItem(
+            id = "h_out",
+            title = "Next month milestone",
+            date = outside,
+            time = LocalTime.NOON,
+            type = TaskType.STUDY,
+            priority = Priority.HIGH))
+  }
+
+  // ────────────────────── Tests ──────────────────────
+
+  @Test
+  fun month_tab_renders_header_and_calendar_card() {
+    val ctx = ApplicationProvider.getApplicationContext<Context>()
+    val vm = buildScheduleVm(ctx)
+
+    val month = YearMonth.of(2025, 9)
+    val selected = month.atDay(15)
+    val tasks = sampleMonthTasks(month)
+
+    val monthName = month.month.name.lowercase().replaceFirstChar { it.uppercase() }
+    val headerTitle = ctx.getString(R.string.calendar_month_year, monthName, month.year)
+
+    rule.setContent {
+      MonthTabContent(
+          allTasks = tasks,
+          selectedDate = selected,
+          currentMonth = month,
+          onPreviousMonthClick = {},
+          onNextMonthClick = {},
+          onDateSelected = { _ -> })
+    }
+
+    // Root month content
+    rule.onNodeWithTag("MonthContent", useUnmergedTree = true).assertExists()
+
+    // Calendar card (MonthGrid container)
+    rule.onNodeWithTag(CalendarScreenTestTags.CALENDAR_CARD, useUnmergedTree = true).assertExists()
+
+    // Header title for the month
+    rule.onNodeWithText(headerTitle).assertIsDisplayed()
+  }
+
+  @Test
+  fun month_tab_shows_only_high_priority_tasks_in_important_section() {
+    val ctx = ApplicationProvider.getApplicationContext<Context>()
+    val vm = buildScheduleVm(ctx)
+
+    val month = YearMonth.of(2025, 11)
+    val selected = month.atDay(3)
+    val tasks = sampleMonthTasks(month)
+
+    rule.setContent {
+      MonthTabContent(
+          allTasks = tasks,
+          selectedDate = selected,
+          currentMonth = month,
+          onPreviousMonthClick = {},
+          onNextMonthClick = {},
+          onDateSelected = { _ -> })
+    }
+
+    // Section title: "Most important this month" (or your localized string)
+    val importantTitle = ctx.getString(R.string.schedule_month_important_title)
+    rule.onNodeWithText(importantTitle).assertIsDisplayed()
+
+    // HIGH priority items inside the month should be visible
+    rule.onNodeWithText("Important exam").assertIsDisplayed()
+    rule.onNodeWithText("Major project deadline").assertIsDisplayed()
+
+    // Medium-priority item from same month should NOT appear in the important list
+    rule.onNodeWithText("Normal homework").assertDoesNotExist()
+
+    // HIGH priority but outside current month should NOT appear either
+    rule.onNodeWithText("Next month milestone").assertDoesNotExist()
+  }
+
+  @Test
+  fun month_tab_shows_noImportantMessage_when_no_high_priority() {
+    val ctx = ApplicationProvider.getApplicationContext<Context>()
+    val vm = buildScheduleVm(ctx)
+
+    val month = YearMonth.of(2025, 4)
+    val selected = month.atDay(8)
+
+    // Only MEDIUM / LOW priority tasks in this month
+    val tasks =
+        listOf(
+            StudyItem(
+                id = "m1",
+                title = "Regular revision",
+                date = month.atDay(5),
+                time = LocalTime.of(9, 0),
+                type = TaskType.STUDY,
+                priority = Priority.MEDIUM),
+            StudyItem(
+                id = "m2",
+                title = "Gym with friend",
+                date = month.atDay(12),
+                time = LocalTime.of(18, 0),
+                type = TaskType.PERSONAL,
+                priority = Priority.LOW))
+
+    rule.setContent {
+      MonthTabContent(
+          allTasks = tasks,
+          selectedDate = selected,
+          currentMonth = month,
+          onPreviousMonthClick = {},
+          onNextMonthClick = {},
+          onDateSelected = { _ -> })
+    }
+
+    val noImportantText = ctx.getString(R.string.schedule_month_no_important)
+
+    // When there is no HIGH priority task in the month, the "no important" text is shown
+    rule.onNodeWithText(noImportantText).assertIsDisplayed()
+  }
+}

--- a/app/src/androidTest/java/com/android/sample/schedule/ScheduleScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/schedule/ScheduleScreenTest.kt
@@ -53,7 +53,6 @@ class ScheduleScreenAllAndroidTest {
     rule.onNodeWithText(ctx.getString(R.string.tab_day)).assertIsDisplayed()
     rule.onNodeWithText(ctx.getString(R.string.tab_week)).assertIsDisplayed()
     rule.onNodeWithText(ctx.getString(R.string.tab_month)).assertIsDisplayed()
-    rule.onNodeWithText(ctx.getString(R.string.tab_agenda)).assertIsDisplayed()
 
     // Day header "Today • <date>"
     val dateText = LocalDate.now().format(DateTimeFormatter.ofPattern("EEEE, MMM d"))
@@ -82,7 +81,6 @@ class ScheduleScreenAllAndroidTest {
     // Click through tabs
     rule.onNodeWithText(ctx.getString(R.string.tab_week)).performClick()
     rule.onNodeWithText(ctx.getString(R.string.tab_month)).performClick()
-    rule.onNodeWithText(ctx.getString(R.string.tab_agenda)).performClick()
 
     // Back to Day
     rule.onNodeWithText(ctx.getString(R.string.tab_day)).performClick()
@@ -112,9 +110,6 @@ class ScheduleScreenAllAndroidTest {
     assertModalFromHere()
 
     rule.onNodeWithText(ctx.getString(R.string.tab_month)).performClick()
-    assertModalFromHere()
-
-    rule.onNodeWithText(ctx.getString(R.string.tab_agenda)).performClick()
     assertModalFromHere()
   }
 

--- a/app/src/androidTest/java/com/android/sample/schedule/ThemedTabRowAndAndroidTest.kt
+++ b/app/src/androidTest/java/com/android/sample/schedule/ThemedTabRowAndAndroidTest.kt
@@ -17,7 +17,7 @@ class ThemedTabRowAndroidTest {
   @Test
   fun clickingTabs_updatesSelectedIndex() {
     var selected by mutableStateOf(0)
-    val labels = listOf("Day", "Week", "Month", "Agenda")
+    val labels = listOf("Day", "Week", "Month")
 
     rule.setContent {
       ThemedTabRow(selected = selected, onSelected = { selected = it }, labels = labels)

--- a/app/src/androidTest/java/com/android/sample/schedule/WeekTabContentTest.kt
+++ b/app/src/androidTest/java/com/android/sample/schedule/WeekTabContentTest.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import androidx.test.core.app.ApplicationProvider
 import com.android.sample.R
+import com.android.sample.feature.schedule.data.calendar.Priority
 import com.android.sample.feature.schedule.data.calendar.StudyItem
 import com.android.sample.feature.schedule.data.calendar.TaskType
 import com.android.sample.feature.schedule.data.schedule.ScheduleEvent
@@ -97,18 +98,21 @@ class WeekTabContentAllAndroidTest {
             title = "Linear Algebra review",
             date = start,
             time = LocalTime.of(9, 0),
+            priority = Priority.MEDIUM,
             type = TaskType.STUDY),
         StudyItem(
             id = "b",
             title = "Part-time shift",
             date = start,
             time = LocalTime.of(16, 0),
+            priority = Priority.MEDIUM,
             type = TaskType.WORK),
         StudyItem(
             id = "c",
             title = "Gym with Sam",
             date = start.plusDays(2),
             time = LocalTime.of(18, 30),
+            priority = Priority.MEDIUM,
             type = TaskType.PERSONAL),
         // outside current week (must not appear)
         StudyItem(
@@ -116,6 +120,7 @@ class WeekTabContentAllAndroidTest {
             title = "Outside week task",
             date = start.plusDays(8),
             time = LocalTime.NOON,
+            priority = Priority.MEDIUM,
             type = TaskType.STUDY))
   }
 

--- a/app/src/androidTest/java/com/android/sample/screen/calendar/DayCellTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/calendar/DayCellTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.sample.feature.schedule.data.calendar.Priority
 import com.android.sample.feature.schedule.data.calendar.StudyItem
 import com.android.sample.feature.schedule.data.calendar.TaskType
 import com.android.sample.ui.calendar.DayCell
@@ -29,8 +30,8 @@ class DayCellTest {
     val date = LocalDate.of(2025, 10, 14)
     val items =
         listOf(
-            StudyItem(title = "A", date = date, type = TaskType.STUDY),
-            StudyItem(title = "B", date = date, type = TaskType.WORK))
+            StudyItem(title = "A", date = date, priority = Priority.MEDIUM, type = TaskType.STUDY),
+            StudyItem(title = "B", date = date, priority = Priority.MEDIUM, type = TaskType.WORK))
     val selected = mutableStateOf(false)
 
     composeRule.setContent {

--- a/app/src/androidTest/java/com/android/sample/screen/calendar/MonthGridTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/calendar/MonthGridTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.onLast
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.sample.feature.schedule.data.calendar.Priority
 import com.android.sample.feature.schedule.data.calendar.StudyItem
 import com.android.sample.feature.schedule.data.calendar.TaskType
 import com.android.sample.ui.calendar.MonthGrid
@@ -29,8 +30,16 @@ class MonthGridTest {
     val selected = mutableStateOf(LocalDate.of(2025, 10, 14))
     val tasks =
         listOf(
-            StudyItem(title = "Meet", date = LocalDate.of(2025, 10, 3), type = TaskType.PERSONAL),
-            StudyItem(title = "Study", date = LocalDate.of(2025, 10, 14), type = TaskType.STUDY))
+            StudyItem(
+                title = "Meet",
+                date = LocalDate.of(2025, 10, 3),
+                priority = Priority.MEDIUM,
+                type = TaskType.PERSONAL),
+            StudyItem(
+                title = "Study",
+                date = LocalDate.of(2025, 10, 14),
+                priority = Priority.MEDIUM,
+                type = TaskType.STUDY))
     var clicked: LocalDate? = null
 
     composeRule.setContent {

--- a/app/src/androidTest/java/com/android/sample/screen/calendar/UpcomingEventsSectionExtraTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/calendar/UpcomingEventsSectionExtraTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.android.sample.feature.schedule.data.calendar.Priority
 import com.android.sample.feature.schedule.data.calendar.StudyItem
 import com.android.sample.feature.schedule.data.calendar.TaskType
 import com.android.sample.ui.calendar.UpcomingEventsSection
@@ -42,9 +43,14 @@ class UpcomingEventsSectionExtraTest {
                 title = "Study Math",
                 date = today,
                 time = LocalTime.of(10, 0),
+                priority = Priority.MEDIUM,
                 type = TaskType.STUDY),
             StudyItem(
-                id = "2", title = "Team meeting", date = today.plusDays(1), type = TaskType.WORK))
+                id = "2",
+                title = "Team meeting",
+                date = today.plusDays(1),
+                priority = Priority.MEDIUM,
+                type = TaskType.WORK))
 
     composeTestRule.setContent {
       UpcomingEventsSection(

--- a/app/src/androidTest/java/com/android/sample/screen/calendar/UpcomingEventsSectionTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/calendar/UpcomingEventsSectionTest.kt
@@ -3,6 +3,7 @@ package com.android.sample.ui.calendar
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import com.android.sample.feature.schedule.data.calendar.Priority
 import com.android.sample.feature.schedule.data.calendar.StudyItem
 import com.android.sample.feature.schedule.data.calendar.TaskType
 import java.time.LocalDate
@@ -24,12 +25,14 @@ class UpcomingEventsSectionTest {
                 title = "Math Revision",
                 date = today,
                 time = LocalTime.of(10, 0),
+                priority = Priority.MEDIUM,
                 type = TaskType.STUDY),
             StudyItem(
                 id = "2",
                 title = "Team Meeting",
                 date = today.plusDays(1),
                 time = LocalTime.of(8, 0),
+                priority = Priority.MEDIUM,
                 type = TaskType.WORK))
 
     composeTestRule.setContent {

--- a/app/src/androidTest/java/com/android/sample/screen/calendar/WeekRowTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/calendar/WeekRowTest.kt
@@ -1,0 +1,101 @@
+package com.android.sample.screen.calendar
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.sample.feature.schedule.data.calendar.Priority
+import com.android.sample.feature.schedule.data.calendar.StudyItem
+import com.android.sample.feature.schedule.data.calendar.TaskType
+import com.android.sample.ui.calendar.WeekRow
+import java.time.LocalDate
+import junit.framework.TestCase.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WeekRowTest {
+
+  @get:Rule val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun weekRow_renders_days_and_propagates_clicks() {
+    val startOfWeek = LocalDate.of(2025, 3, 3) // Monday 3
+    val selected = mutableStateOf(startOfWeek)
+    var clicked: LocalDate? = null
+
+    composeRule.setContent {
+      MaterialTheme {
+        WeekRow(
+            startOfWeek = startOfWeek,
+            selectedDate = selected.value,
+            allTasks = emptyList(),
+            onDayClick = { d ->
+              clicked = d
+              selected.value = d
+            })
+      }
+    }
+
+    val firstDayLabel = startOfWeek.dayOfMonth.toString() // "3"
+    val secondDay = startOfWeek.plusDays(1) // "4"
+
+    composeRule.onNodeWithText(firstDayLabel).assertExists()
+    composeRule.onNodeWithText(secondDay.dayOfMonth.toString()).assertExists()
+
+    composeRule.onNodeWithText(secondDay.dayOfMonth.toString()).performClick()
+
+    assertEquals(secondDay, clicked)
+  }
+
+  @Test
+  fun weekRow_shows_plusMore_when_more_than_two_events() {
+    val ctx = composeRule.activity
+    val startOfWeek = LocalDate.of(2025, 5, 5) // Monday
+    val busyDay = startOfWeek.plusDays(2) // Wednesday
+
+    val tasks =
+        listOf(
+            StudyItem(
+                title = "Very long first event title that should be truncated",
+                date = busyDay,
+                type = TaskType.STUDY,
+                priority = Priority.MEDIUM),
+            StudyItem(
+                title = "Second event",
+                date = busyDay,
+                type = TaskType.STUDY,
+                priority = Priority.MEDIUM),
+            StudyItem(
+                title = "Third event",
+                date = busyDay,
+                type = TaskType.WORK,
+                priority = Priority.MEDIUM),
+            StudyItem(
+                title = "Fourth event",
+                date = busyDay,
+                type = TaskType.PERSONAL,
+                priority = Priority.MEDIUM))
+
+    composeRule.setContent {
+      MaterialTheme {
+        WeekRow(
+            startOfWeek = startOfWeek,
+            selectedDate = startOfWeek,
+            allTasks = tasks,
+            onDayClick = {})
+      }
+    }
+
+    composeRule.onNodeWithText("Second event", substring = false).assertExists()
+
+    composeRule.onNodeWithText("Third event", substring = true).assertDoesNotExist()
+
+    val moreText = ctx.getString(com.android.sample.R.string.calendar_more_events, 2)
+    composeRule.onNodeWithText(moreText).assertExists()
+  }
+}

--- a/app/src/main/java/com/android/sample/feature/schedule/data/schedule/ScheduleEvent.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/data/schedule/ScheduleEvent.kt
@@ -83,6 +83,5 @@ enum class SourceTag {
 enum class ScheduleTab {
   DAY,
   WEEK,
-  MONTH,
-  AGENDA
+  MONTH
 }

--- a/app/src/main/java/com/android/sample/ui/calendar/CalendarGrids.kt
+++ b/app/src/main/java/com/android/sample/ui/calendar/CalendarGrids.kt
@@ -180,16 +180,17 @@ private fun WeekDayCard(
     tasksForDay: List<StudyItem>,
     onDayClick: (LocalDate) -> Unit
 ) {
+  val tagShape = RoundedCornerShape(8.dp)
   Box(
       modifier =
           Modifier.width(140.dp)
               .height(160.dp)
-              .clip(RoundedCornerShape(18.dp))
+              .clip(tagShape)
               .background(brush = Brush.verticalGradient(listOf(Blue, DarkerBlue)))
               .border(
                   width = if (isSelected) 2.dp else 1.dp,
                   color = if (isSelected) PurpleBorder else PurplePrimary.copy(alpha = 0.4f),
-                  shape = RoundedCornerShape(18.dp))
+                  shape = tagShape)
               .clickable { onDayClick(day) }
               .padding(10.dp)
               .testTag("${CalendarScreenTestTags.WEEK_DAY_BOX_PREFIX}${day.dayOfMonth}")) {

--- a/app/src/main/java/com/android/sample/ui/calendar/CalendarGrids.kt
+++ b/app/src/main/java/com/android/sample/ui/calendar/CalendarGrids.kt
@@ -55,28 +55,17 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.YearMonth
 
+/** This class was implemented with the help of ai (chatgbt) */
 @Composable
 fun MonthGrid(
     currentMonth: YearMonth,
     selectedDate: LocalDate,
     allTasks: List<StudyItem>,
-    onDateClick: (LocalDate) -> Unit,
-    onPrevClick: () -> Unit,
-    onNextClick: () -> Unit
+    onDateClick: (LocalDate) -> Unit
 ) {
-  val monthName =
-      remember(currentMonth) {
-        currentMonth.month.name.lowercase().replaceFirstChar { it.uppercase() }
-      }
-
-  val title = stringResource(id = R.string.calendar_month_year, monthName, currentMonth.year)
-
-  // Group tasks by date once, recompute only when allTasks changes
   val tasksByDate = remember(allTasks) { allTasks.groupBy { it.date } }
 
   Column(modifier = Modifier.padding(20.dp), horizontalAlignment = Alignment.CenterHorizontally) {
-    CalendarHeader(title = title, onPrevClick = onPrevClick, onNextClick = onNextClick)
-
     Row(
         modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
         horizontalArrangement = Arrangement.SpaceBetween) {
@@ -180,17 +169,16 @@ private fun WeekDayCard(
     tasksForDay: List<StudyItem>,
     onDayClick: (LocalDate) -> Unit
 ) {
-  val tagShape = RoundedCornerShape(8.dp)
   Box(
       modifier =
           Modifier.width(140.dp)
               .height(160.dp)
-              .clip(tagShape)
+              .clip(RoundedCornerShape(18.dp))
               .background(brush = Brush.verticalGradient(listOf(Blue, DarkerBlue)))
               .border(
                   width = if (isSelected) 2.dp else 1.dp,
                   color = if (isSelected) PurpleBorder else PurplePrimary.copy(alpha = 0.4f),
-                  shape = tagShape)
+                  shape = RoundedCornerShape(18.dp))
               .clickable { onDayClick(day) }
               .padding(10.dp)
               .testTag("${CalendarScreenTestTags.WEEK_DAY_BOX_PREFIX}${day.dayOfMonth}")) {

--- a/app/src/main/java/com/android/sample/ui/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/calendar/CalendarScreen.kt
@@ -115,9 +115,7 @@ fun CalendarScreen(vm: CalendarViewModel = viewModel()) {
                           currentMonth = currentMonth,
                           selectedDate = selectedDate,
                           allTasks = allTasks,
-                          onDateClick = { vm.onDateSelected(it) },
-                          onPrevClick = { vm.onPreviousMonthWeekClicked() },
-                          onNextClick = { vm.onNextMonthWeekClicked() })
+                          onDateClick = { vm.onDateSelected(it) })
                     } else {
                       WeekRow(
                           startOfWeek = vm.startOfWeek(selectedDate),

--- a/app/src/main/java/com/android/sample/ui/schedule/MonthTabContent.kt
+++ b/app/src/main/java/com/android/sample/ui/schedule/MonthTabContent.kt
@@ -1,0 +1,157 @@
+package com.android.sample.ui.schedule
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.android.sample.R
+import com.android.sample.feature.schedule.data.calendar.Priority
+import com.android.sample.feature.schedule.data.calendar.StudyItem
+import com.android.sample.ui.calendar.CalendarHeader
+import com.android.sample.ui.calendar.CalendarScreenTestTags
+import com.android.sample.ui.calendar.MonthGrid
+import com.android.sample.ui.theme.DarkBlue
+import java.time.LocalDate
+import java.time.YearMonth
+
+/** This class was implemented with the help of ai (chatgbt) */
+const val MONTH_CONTENT_TEST_TAG = "MonthContent"
+
+@Composable
+fun MonthTabContent(
+    allTasks: List<StudyItem>,
+    selectedDate: LocalDate,
+    currentMonth: YearMonth,
+    onPreviousMonthClick: () -> Unit,
+    onNextMonthClick: () -> Unit,
+    onDateSelected: (LocalDate) -> Unit,
+) {
+  val monthName = currentMonth.month.name.lowercase().replaceFirstChar { it.uppercase() }
+  val headerTitle = stringResource(id = R.string.calendar_month_year, monthName, currentMonth.year)
+
+  LazyColumn(
+      modifier = Modifier.fillMaxSize().testTag(MONTH_CONTENT_TEST_TAG),
+      verticalArrangement = Arrangement.spacedBy(16.dp),
+      contentPadding = PaddingValues(bottom = 96.dp)) {
+        item("month-big-frame") {
+
+          // ONE AND ONLY big frame — like WeekTabContent
+          SectionBox(title = null, header = null) {
+
+            // ───────────── Header ─────────────
+            CalendarHeader(
+                title = headerTitle,
+                onPrevClick = onPreviousMonthClick,
+                onNextClick = onNextMonthClick)
+
+            Spacer(Modifier.height(8.dp))
+
+            // ───────────── Card with MonthGrid ─────────────
+            Card(
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .shadow(8.dp)
+                        .testTag(CalendarScreenTestTags.CALENDAR_CARD),
+                colors = CardDefaults.cardColors(containerColor = DarkBlue.copy(alpha = 0.85f)),
+                shape = RoundedCornerShape(24.dp)) {
+                  Box(
+                      modifier =
+                          Modifier.fillMaxWidth()
+                              .heightIn(min = 260.dp, max = 420.dp)
+                              .padding(horizontal = 8.dp, vertical = 6.dp)) {
+                        MonthGrid(
+                            currentMonth = currentMonth,
+                            selectedDate = selectedDate,
+                            allTasks = allTasks,
+                            onDateClick = { onDateSelected })
+                      }
+                }
+
+            Spacer(Modifier.height(16.dp))
+
+            // ───────────── Most important this month (HIGH priority only) ─────────────
+            val monthStart = currentMonth.atDay(1)
+            val monthEnd = monthStart.plusMonths(1).minusDays(1)
+
+            val highPriorityMonthTasks =
+                allTasks
+                    .filter { it.date in monthStart..monthEnd && it.priority == Priority.HIGH }
+                    .distinctBy { it.id }
+                    .sortedWith(
+                        compareBy<StudyItem>({ it.date }, { it.time ?: java.time.LocalTime.MIN }))
+
+            SectionBox(
+                header = {
+                  Text(
+                      text = stringResource(R.string.schedule_month_important_title),
+                      style =
+                          MaterialTheme.typography.titleMedium.copy(
+                              fontSize = 20.sp, fontWeight = FontWeight.Bold, color = Color.White),
+                      modifier = Modifier.fillMaxWidth().padding(bottom = 14.dp))
+                }) {
+                  val cs = MaterialTheme.colorScheme
+
+                  if (highPriorityMonthTasks.isEmpty()) {
+                    Text(
+                        text = stringResource(R.string.schedule_month_no_important),
+                        color = cs.onSurfaceVariant,
+                        modifier = Modifier.fillMaxWidth())
+                  } else {
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                      highPriorityMonthTasks.forEach { task ->
+                        Row(modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp)) {
+
+                          // small colored bar on the left
+                          Box(
+                              modifier =
+                                  Modifier.width(5.dp)
+                                      .height(32.dp)
+                                      .background(cs.primary, RoundedCornerShape(999.dp)))
+
+                          Spacer(Modifier.width(10.dp))
+
+                          Column(modifier = Modifier.fillMaxWidth()) {
+                            Text(
+                                text = task.title,
+                                style =
+                                    MaterialTheme.typography.bodyMedium.copy(
+                                        fontWeight = FontWeight.SemiBold, color = cs.onSurface))
+                            Text(
+                                text = task.date.toString(), // format later if you want
+                                style =
+                                    MaterialTheme.typography.labelSmall.copy(
+                                        color = cs.onSurfaceVariant))
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+          }
+        }
+      }
+}

--- a/app/src/main/java/com/android/sample/ui/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/schedule/ScheduleScreen.kt
@@ -36,6 +36,7 @@ import com.android.sample.ui.theme.BackgroundDark
 import com.android.sample.ui.theme.BackgroundGradientEnd
 import com.android.sample.ui.theme.PurplePrimary
 import java.time.LocalDate
+import java.time.YearMonth
 
 /** This class was implemented with the help of ai (chatgbt) */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -108,8 +109,7 @@ fun ScheduleScreen() {
                   when (currentTab) {
                     ScheduleTab.DAY -> LocalDate.now()
                     ScheduleTab.WEEK -> vm.startOfWeek(state.selectedDate)
-                    ScheduleTab.MONTH,
-                    ScheduleTab.AGENDA -> state.selectedDate
+                    ScheduleTab.MONTH -> state.selectedDate
                   }
               showAddModal = true
             },
@@ -141,8 +141,7 @@ fun ScheduleScreen() {
                       listOf(
                           stringResource(R.string.tab_day),
                           stringResource(R.string.tab_week),
-                          stringResource(R.string.tab_month),
-                          stringResource(R.string.tab_agenda)))
+                          stringResource(R.string.tab_month)))
 
               Spacer(Modifier.height(8.dp))
               if (state.isAdjustingPlan) {
@@ -161,10 +160,13 @@ fun ScheduleScreen() {
                       selectedDate = state.selectedDate)
                 }
                 ScheduleTab.MONTH -> {
-                  // TODO: implement Month
-                }
-                ScheduleTab.AGENDA -> {
-                  // TODO: implement Agenda
+                  MonthTabContent(
+                      currentMonth = YearMonth.from(state.selectedDate),
+                      allTasks = allTasks,
+                      selectedDate = state.selectedDate,
+                      onPreviousMonthClick = { vm.onPreviousMonthWeekClicked() },
+                      onNextMonthClick = { vm.onNextMonthWeekClicked() },
+                      onDateSelected = { vm.onDateSelected(it) })
                 }
               }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -205,7 +205,6 @@
     <string name="tab_day">Day</string>
     <string name="tab_week">Week</string>
     <string name="tab_month">Month</string>
-    <string name="tab_agenda">Agenda</string>
 
     <!-- Today card -->
     <string name="today_title_fmt">Today • %1$s</string>
@@ -255,5 +254,7 @@
     <string name="calendar_more_events">+%1$d more</string>
     <string name="week_progression">Week progression</string>
 
+    <string name="schedule_month_important_title">Most important this month</string>
+    <string name="schedule_month_no_important">No important events this month</string>
 
 </resources>

--- a/app/src/test/java/com/android/sample/screen/calendar/PlannerRepositoryImplTest.kt
+++ b/app/src/test/java/com/android/sample/screen/calendar/PlannerRepositoryImplTest.kt
@@ -1,5 +1,6 @@
 package com.android.sample.screen.calendar
 
+import com.android.sample.feature.schedule.data.calendar.Priority
 import com.android.sample.feature.schedule.data.calendar.StudyItem
 import com.android.sample.feature.schedule.data.calendar.TaskType
 import com.android.sample.feature.schedule.repository.calendar.CalendarRepository
@@ -23,6 +24,7 @@ class PlannerRepositoryImplTest {
             date = d,
             time = LocalTime.of(9, 30),
             durationMinutes = 45,
+            priority = Priority.MEDIUM,
             type = TaskType.WORK)
 
     // create
@@ -49,7 +51,11 @@ class PlannerRepositoryImplTest {
 
     val newItem =
         StudyItem(
-            title = "New", date = LocalDate.now(), durationMinutes = null, type = TaskType.PERSONAL)
+            title = "New",
+            date = LocalDate.now(),
+            durationMinutes = null,
+            type = TaskType.PERSONAL,
+            priority = Priority.MEDIUM)
     repo.saveTask(newItem)
     Assert.assertEquals(initial + 1, repo.getAllTasks().size)
 

--- a/app/src/test/java/com/android/sample/screen/calendar/StudyItemTest.kt
+++ b/app/src/test/java/com/android/sample/screen/calendar/StudyItemTest.kt
@@ -39,6 +39,7 @@ class StudyItemTest {
         StudyItem(
             title = "Untimed",
             date = d,
+            priority = Priority.MEDIUM,
             type = TaskType.WORK // leave description/time/duration at defaults
             )
 
@@ -56,7 +57,10 @@ class StudyItemTest {
   @Test
   fun uuid_is_unique_across_instances() {
     val d = LocalDate.of(2025, 1, 2)
-    val items = (0 until 10).map { StudyItem(title = "t$it", date = d, type = TaskType.PERSONAL) }
+    val items =
+        (0 until 10).map {
+          StudyItem(title = "t$it", date = d, priority = Priority.MEDIUM, type = TaskType.PERSONAL)
+        }
     val distinctIds = items.map { it.id }.toSet()
     assertEquals(items.size, distinctIds.size)
   }
@@ -164,8 +168,8 @@ class StudyItemTest {
   fun calendarUiState_custom_values_are_preserved() {
     val d1 = LocalDate.of(2025, 2, 10)
     val d2 = LocalDate.of(2025, 2, 11)
-    val item1 = StudyItem(title = "A", date = d1, type = TaskType.STUDY)
-    val item2 = StudyItem(title = "B", date = d2, type = TaskType.WORK)
+    val item1 = StudyItem(title = "A", date = d1, priority = Priority.MEDIUM, type = TaskType.STUDY)
+    val item2 = StudyItem(title = "B", date = d2, priority = Priority.MEDIUM, type = TaskType.WORK)
     val map = mapOf(d1 to listOf(item1), d2 to listOf(item2))
     val ym = YearMonth.of(2025, 2)
     val s =
@@ -188,7 +192,8 @@ class StudyItemTest {
   @Test
   fun calendarUiState_copy_toggles_modal_and_selection() {
     val d = LocalDate.of(2025, 7, 20)
-    val i = StudyItem(title = "Edit me", date = d, type = TaskType.PERSONAL)
+    val i =
+        StudyItem(title = "Edit me", date = d, priority = Priority.MEDIUM, type = TaskType.PERSONAL)
     val s = CalendarUiState(selectedDate = d, isShowingAddEditModal = false, taskToEdit = null)
 
     val s2 = s.copy(isShowingAddEditModal = true, taskToEdit = i)
@@ -206,9 +211,23 @@ class StudyItemTest {
   @Test
   fun tasks_can_be_sorted_by_date_then_time_nulls_last() {
     val d = LocalDate.of(2025, 9, 1)
-    val a = StudyItem(title = "A", date = d, time = LocalTime.of(8, 0), type = TaskType.STUDY)
-    val b = StudyItem(title = "B", date = d, time = LocalTime.of(7, 30), type = TaskType.STUDY)
-    val c = StudyItem(title = "C", date = d, time = null, type = TaskType.STUDY)
+    val a =
+        StudyItem(
+            title = "A",
+            date = d,
+            time = LocalTime.of(8, 0),
+            priority = Priority.MEDIUM,
+            type = TaskType.STUDY)
+    val b =
+        StudyItem(
+            title = "B",
+            date = d,
+            time = LocalTime.of(7, 30),
+            priority = Priority.MEDIUM,
+            type = TaskType.STUDY)
+    val c =
+        StudyItem(
+            title = "C", date = d, time = null, priority = Priority.MEDIUM, type = TaskType.STUDY)
     val list =
         listOf(a, b, c)
             .sortedWith(compareBy<StudyItem> { it.date }.thenBy { it.time ?: LocalTime.MAX })

--- a/app/src/test/java/com/android/sample/ui/schedule/ScheduleRepositoryImplTest.kt
+++ b/app/src/test/java/com/android/sample/ui/schedule/ScheduleRepositoryImplTest.kt
@@ -3,6 +3,7 @@ package com.android.sample.ui.schedule
 // fake
 import android.content.res.Resources
 import androidx.test.core.app.ApplicationProvider
+import com.android.sample.feature.schedule.data.calendar.Priority
 import com.android.sample.feature.schedule.data.calendar.StudyItem
 import com.android.sample.feature.schedule.data.calendar.TaskType
 import com.android.sample.feature.schedule.data.schedule.EventKind
@@ -71,9 +72,17 @@ class ScheduleRepositoryImplTest {
         tasksRepo.emitTasks(
             listOf(
                 StudyItem(
-                    title = "T0", date = today, time = LocalTime.of(8, 0), type = TaskType.STUDY),
+                    title = "T0",
+                    date = today,
+                    time = LocalTime.of(8, 0),
+                    priority = Priority.MEDIUM,
+                    type = TaskType.STUDY),
                 StudyItem(
-                    title = "T1", date = today, time = LocalTime.of(10, 0), type = TaskType.STUDY)))
+                    title = "T1",
+                    date = today,
+                    time = LocalTime.of(10, 0),
+                    priority = Priority.MEDIUM,
+                    type = TaskType.STUDY)))
         // classesRepo already emits [Algorithms 9:00, Data Structures 11:00, Networks 14:00]
         advanceUntilIdle()
 

--- a/app/src/test/java/com/android/sample/ui/schedule/StudyItemMapperTest.kt
+++ b/app/src/test/java/com/android/sample/ui/schedule/StudyItemMapperTest.kt
@@ -82,7 +82,8 @@ class StudyItemMapperTest {
             title = "Project report",
             description = "final deadline",
             date = LocalDate.of(2025, 11, 10),
-            type = TaskType.WORK)
+            type = TaskType.WORK,
+            priority = ModelPriority.MEDIUM)
 
     val ev = StudyItemMapper.toScheduleEvent(item, resources)
     assertEquals(EventKind.SUBMISSION_PROJECT, ev.kind)
@@ -91,7 +92,11 @@ class StudyItemMapperTest {
   @Test
   fun toScheduleEvent_guessActivityKind_sportByKeyword() {
     val item =
-        StudyItem(title = "Gym session", date = LocalDate.of(2025, 11, 9), type = TaskType.PERSONAL)
+        StudyItem(
+            title = "Gym session",
+            date = LocalDate.of(2025, 11, 9),
+            priority = ModelPriority.MEDIUM,
+            type = TaskType.PERSONAL)
 
     val ev = StudyItemMapper.toScheduleEvent(item, resources)
     assertEquals(EventKind.ACTIVITY_SPORT, ev.kind)


### PR DESCRIPTION
## Summary:

This PR introduces the fully functional Month View to the Schedule screen, completing the Day/Week/Month tab experience. It includes a month grid, navigation, and a high-priority tasks section, all integrated with ScheduleViewModel.

## What’s in This PR:

Added a unified MonthTabContent with:

- CalendarHeader (prev/next month)
- MonthGrid inside a styled card
- “Most Important This Month” list (HIGH priority only)

## Testing:
New Month view tests: modal visibility, status rendering, screen container, themed tabs.

## Screenshots:
<img width="325" height="668" alt="Capture d&#39;écran 2025-11-13 225306" src="https://github.com/user-attachments/assets/a3f926a9-3abe-4195-bfde-ee6ec283e538" />
<img width="320" height="656" alt="Capture d&#39;écran 2025-11-13 225320" src="https://github.com/user-attachments/assets/eeeeb2ca-62f5-47fb-a887-e8791c095e77" />

## Notes:
This pr was implemented with the help of ai (chatgbt).

## Issue Reference:

Closes #136
