### PR TITLE
Feat(end-to-end test1)

### DIFF
--- a/app/src/androidTest/java/com/android/sample/PlannerCalendarEndToEndTest.kt
+++ b/app/src/androidTest/java/com/android/sample/PlannerCalendarEndToEndTest.kt
@@ -149,9 +149,12 @@ class HomePlannerCalendarStudyEndToEndTest {
 
     composeRule.onNodeWithTag(NavigationTestTags.GO_BACK_BUTTON).assertExists().performClick()
 
+    composeRule.waitForIdle()
+    composeRule.mainClock.advanceTimeBy(500)
+    composeRule.waitForIdle()
+
     composeRule.waitUntilExactlyOneExists(
-        hasTestTag(HomeTestTags.MENU_BUTTON), timeoutMillis = 5_000)
-    composeRule.onNodeWithTag(HomeTestTags.MENU_BUTTON).assertExists()
+        hasTestTag(HomeTestTags.MENU_BUTTON), timeoutMillis = 20_000)
 
     // 7) Home -> Study via quick action
     // Scroll the home scrollable content until QUICK_STUDY is in view

--- a/app/src/androidTest/java/com/android/sample/PlannerCalendarEndToEndTest.kt
+++ b/app/src/androidTest/java/com/android/sample/PlannerCalendarEndToEndTest.kt
@@ -1,0 +1,180 @@
+package com.android.sample
+
+// This code has been written partially using A.I (LLM).
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.android.sample.feature.homeScreen.AppDestination
+import com.android.sample.feature.homeScreen.HomeTestTags
+import com.android.sample.ui.calendar.CalendarScreenTestTags
+import com.android.sample.ui.login.LoginScreen
+import com.android.sample.ui.planner.PlannerScreenTestTags
+import com.android.sample.ui.session.StudySessionTestTags
+import com.android.sample.ui.theme.EduMonTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class HomePlannerCalendarStudyEndToEndTest {
+
+  @get:Rule val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+  private lateinit var loggedInState: MutableState<Boolean>
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun login_home_planner_calendar_study_flow_works_end_to_end() {
+    // Single setContent for the whole flow
+    composeRule.setContent {
+      EduMonTheme {
+        val loggedIn = remember { mutableStateOf(false) }
+        loggedInState = loggedIn
+
+        if (!loggedIn.value) {
+          LoginScreen(onLoggedIn = { loggedIn.value = true })
+        } else {
+          EduMonNavHost()
+        }
+      }
+    }
+
+    composeRule.waitUntilExactlyOneExists(
+        hasText("Connect yourself to EduMon."), timeoutMillis = 5_000)
+    composeRule.onNodeWithText("Connect yourself to EduMon.").assertExists()
+    composeRule.onNodeWithText("Continue with Google").assertExists()
+
+    composeRule.runOnIdle { loggedInState.value = true }
+
+    // 1) HOME + NAV HOST
+    composeRule.waitUntilExactlyOneExists(
+        hasTestTag(HomeTestTags.MENU_BUTTON), timeoutMillis = 10_000)
+    composeRule.waitUntilExactlyOneExists(
+        hasTestTag(NavigationTestTags.NAV_HOST), timeoutMillis = 10_000)
+
+    composeRule.onNodeWithTag(HomeTestTags.MENU_BUTTON).assertExists()
+
+    composeRule.onNodeWithTag(HomeTestTags.CHIP_OPEN_PLANNER).assertExists().performClick()
+
+    composeRule.waitUntilExactlyOneExists(
+        hasTestTag(PlannerScreenTestTags.PLANNER_SCREEN), timeoutMillis = 5_000)
+
+    composeRule.onNodeWithTag(PlannerScreenTestTags.PLANNER_SCREEN).assertExists()
+
+    composeRule.onNodeWithTag(PlannerScreenTestTags.PET_HEADER).assertExists()
+    composeRule.onNodeWithTag(PlannerScreenTestTags.TODAY_CLASSES_SECTION).assertExists()
+
+    composeRule
+        .onNodeWithTag(PlannerScreenTestTags.PLANNER_SCREEN)
+        .performScrollToNode(hasTestTag(PlannerScreenTestTags.WELLNESS_CAMPUS_SECTION))
+    composeRule.onNodeWithTag(PlannerScreenTestTags.WELLNESS_CAMPUS_SECTION).assertExists()
+
+    // 3) Open Add Study Task modal
+    composeRule.onNodeWithTag("addTaskFab").assertExists().performClick()
+
+    composeRule.waitUntilExactlyOneExists(
+        hasTestTag(PlannerScreenTestTags.ADD_TASK_MODAL), timeoutMillis = 5_000)
+    composeRule.onNodeWithTag(PlannerScreenTestTags.ADD_TASK_MODAL).assertExists()
+
+    composeRule.onNodeWithTag(PlannerScreenTestTags.SUBJECT_FIELD).apply {
+      performTextClearance()
+      performTextInput("Algebra 1")
+    }
+
+    composeRule.onNodeWithTag(PlannerScreenTestTags.TASK_TITLE_FIELD).apply {
+      performTextClearance()
+      performTextInput("Problem set 3")
+    }
+
+    composeRule.onNodeWithTag(PlannerScreenTestTags.DURATION_FIELD).apply {
+      performTextClearance()
+      performTextInput("90")
+    }
+
+    composeRule.onNodeWithTag(PlannerScreenTestTags.DEADLINE_FIELD).apply {
+      performTextClearance()
+      performTextInput("2025-11-20")
+    }
+
+    composeRule.onNodeWithTag("aaddTaskButton").assertExists().performClick()
+
+    composeRule.waitUntil(timeoutMillis = 5_000) {
+      composeRule
+          .onAllNodesWithTag(PlannerScreenTestTags.ADD_TASK_MODAL)
+          .fetchSemanticsNodes()
+          .isEmpty()
+    }
+
+    composeRule.onNodeWithTag(NavigationTestTags.GO_BACK_BUTTON).assertExists().performClick()
+
+    composeRule.waitUntilExactlyOneExists(
+        hasTestTag(HomeTestTags.MENU_BUTTON), timeoutMillis = 5_000)
+    composeRule.onNodeWithTag(HomeTestTags.MENU_BUTTON).assertExists()
+
+    // 5) Home -> Calendar via bottom nav
+    composeRule
+        .onNodeWithTag(HomeTestTags.bottomTag(AppDestination.Calendar.route))
+        .assertExists()
+        .performClick()
+
+    composeRule.waitUntilExactlyOneExists(
+        hasTestTag(CalendarScreenTestTags.CALENDAR_CARD), timeoutMillis = 5_000)
+
+    composeRule.onNodeWithTag(CalendarScreenTestTags.CALENDAR_HEADER).assertExists()
+    composeRule.onNodeWithTag(CalendarScreenTestTags.CALENDAR_CARD).assertExists()
+
+    composeRule
+        .onNodeWithTag(CalendarScreenTestTags.VIEW_TOGGLE_BUTTON)
+        .assertExists()
+        .performClick()
+
+    composeRule.onNodeWithTag(CalendarScreenTestTags.CALENDAR_CARD).assertExists()
+
+    composeRule.onNodeWithTag(NavigationTestTags.GO_BACK_BUTTON).assertExists().performClick()
+
+    composeRule.waitUntilExactlyOneExists(
+        hasTestTag(HomeTestTags.MENU_BUTTON), timeoutMillis = 5_000)
+    composeRule.onNodeWithTag(HomeTestTags.MENU_BUTTON).assertExists()
+
+    // 7) Home -> Study via quick action
+    // Scroll the home scrollable content until QUICK_STUDY is in view
+    composeRule.onNode(hasScrollAction()).performScrollToNode(hasTestTag(HomeTestTags.QUICK_STUDY))
+
+    composeRule.onNodeWithTag(HomeTestTags.QUICK_STUDY).assertExists().performClick()
+
+    composeRule.waitUntilExactlyOneExists(
+        hasTestTag(NavigationTestTags.TOP_BAR_TITLE), timeoutMillis = 5_000)
+
+    composeRule
+        .onNode(hasTestTag(NavigationTestTags.TOP_BAR_TITLE) and hasText("Study"))
+        .assertExists()
+
+    // Study session core UI
+    composeRule.onNodeWithTag(StudySessionTestTags.TIMER_SECTION).assertExists()
+    composeRule.onNodeWithTag(StudySessionTestTags.STATS_PANEL).assertExists()
+
+    // 8) Study -> Home
+    composeRule.onNodeWithTag(NavigationTestTags.GO_BACK_BUTTON).assertExists().performClick()
+
+    composeRule.waitUntilExactlyOneExists(
+        hasTestTag(HomeTestTags.MENU_BUTTON), timeoutMillis = 5_000)
+    composeRule.onNodeWithTag(HomeTestTags.MENU_BUTTON).assertExists()
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces a full meaningfull and stabilized end-to-end test file:
HomePlannerCalendarStudyEndToEndTest.kt.

## What’s in this PR
Not really changes to the application since it's just and end-to-test, so nothing new concretely.

## Implementation Notes

- Single setContent per test to comply with Compose test rule requirements.
- Use of waitUntilExactlyOneExists to avoid race conditions at startup.
- For stability, assertExists() is used instead of assertIsDisplayed() unless visibility is mandatory.

## Testing
**Unit Tests:**

No new units added.

**Instrumented UI Tests:**

The new test covers:

- Login UI presence
- Home main sections
- Planner screen structure
- Add Study Task modal
- Calendar screen
- Study Session screen
- Back navigation
- Scroll-dependent UI nodes (LazyColumn + Home scroll)
- Full navigation graph stability for the user journey

This is now the most complete E2E test in the suite.

## Screenshots / Demos

No screenshot since we only added a test.

## Checklist
- [x]  One setContent per test
- [x]  Login UI included and simulated correctly
- [x]  Home loads reliably
- [x]  Planner + AddTask modal flows covered
- [x]  Calendar navigation validated
- [x]  Study session validated
- [x]  Proper scrolling for off-screen elements
- [x]  No network / Firebase dependencies
- [x]  Code mirrors project style

## Notes
An LLM has been used to generate parts of this test, and of this PR.

## Issue Reference
Closes #142 

