### PR TITLE
feat(UserStats): User stats are centralized into 1 location on Firestore.

### DIFF
--- a/app/src/main/java/com/android/sample/data/FakeUserStatsRepository.kt
+++ b/app/src/main/java/com/android/sample/data/FakeUserStatsRepository.kt
@@ -1,0 +1,53 @@
+package com.android.sample.data
+
+// This code has been written partially using A.I (LLM).
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/** In-memory fake implementation of UserStatsRepository for tests and previews. */
+class FakeUserStatsRepository(initial: UserStats = UserStats()) : UserStatsRepository {
+
+  private companion object {
+    private const val DEFAULT_INT_DELTA = 0
+  }
+
+  private val _stats = MutableStateFlow(initial)
+  override val stats: StateFlow<UserStats> = _stats
+
+  override fun start() {
+    // No-op: everything is in memory.
+  }
+
+  override suspend fun addStudyMinutes(extraMinutes: Int) {
+    if (extraMinutes <= DEFAULT_INT_DELTA) {
+      return
+    }
+    val current = _stats.value
+    _stats.value =
+        current.copy(
+            totalStudyMinutes = current.totalStudyMinutes + extraMinutes,
+            todayStudyMinutes = current.todayStudyMinutes + extraMinutes)
+  }
+
+  override suspend fun updateCoins(delta: Int) {
+    if (delta == DEFAULT_INT_DELTA) {
+      return
+    }
+    val current = _stats.value
+    _stats.value = current.copy(coins = current.coins + delta)
+  }
+
+  override suspend fun setWeeklyGoal(goalMinutes: Int) {
+    val current = _stats.value
+    _stats.value = current.copy(weeklyGoal = goalMinutes)
+  }
+
+  override suspend fun addPoints(delta: Int) {
+    if (delta == DEFAULT_INT_DELTA) {
+      return
+    }
+    val current = _stats.value
+    _stats.value = current.copy(points = current.points + delta)
+  }
+}

--- a/app/src/main/java/com/android/sample/data/FirestoreUserStatsRepository.kt
+++ b/app/src/main/java/com/android/sample/data/FirestoreUserStatsRepository.kt
@@ -1,0 +1,234 @@
+package com.android.sample.data
+
+// This code has been written partially using A.I (LLM).
+
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.SetOptions
+import java.util.Calendar
+import java.util.TimeZone
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Firestore-backed implementation of UserStatsRepository.
+ *
+ * Single canonical document: /users/{uid}/stats/stats
+ */
+class FirestoreUserStatsRepository(
+    private val auth: FirebaseAuth,
+    private val firestore: FirebaseFirestore
+) : UserStatsRepository {
+
+  private companion object {
+    private const val USERS_COLLECTION = "users"
+    private const val STATS_COLLECTION = "stats"
+    private const val STATS_DOCUMENT_ID = "stats"
+
+    private const val FIELD_TOTAL_STUDY_MINUTES = "totalStudyMinutes"
+    private const val FIELD_TODAY_STUDY_MINUTES = "todayStudyMinutes"
+    private const val FIELD_STREAK = "streak"
+    private const val FIELD_WEEKLY_GOAL = "weeklyGoal"
+    private const val FIELD_COINS = "coins"
+    private const val FIELD_POINTS = "points"
+    private const val FIELD_LAST_UPDATED = "lastUpdated"
+
+    private const val DEFAULT_INT_VALUE = 0
+    private const val DEFAULT_LONG_VALUE = 0L
+  }
+
+  private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+  private val _stats = MutableStateFlow(UserStats())
+  override val stats: StateFlow<UserStats> = _stats
+
+  private var hasStarted = false
+
+  override fun start() {
+    if (hasStarted) {
+      return
+    }
+
+    val currentUser = auth.currentUser ?: return
+    hasStarted = true
+
+    val docRef =
+        firestore
+            .collection(USERS_COLLECTION)
+            .document(currentUser.uid)
+            .collection(STATS_COLLECTION)
+            .document(STATS_DOCUMENT_ID)
+
+    docRef.addSnapshotListener { snapshot, error ->
+      if (error != null) {
+        // You can log this error if needed.
+        return@addSnapshotListener
+      }
+
+      if (snapshot == null || !snapshot.exists()) {
+        scope.launch { ensureDefaultDocument(currentUser.uid) }
+        return@addSnapshotListener
+      }
+
+      val data = snapshot.data ?: emptyMap<String, Any>()
+      val rawStats = data.toUserStats()
+      val now = System.currentTimeMillis()
+
+      val sameDay =
+          if (rawStats.lastUpdated == DEFAULT_LONG_VALUE) {
+            true
+          } else {
+            isSameDay(rawStats.lastUpdated, now)
+          }
+
+      val adjusted =
+          if (sameDay) {
+            rawStats
+          } else {
+            rawStats.copy(todayStudyMinutes = DEFAULT_INT_VALUE, lastUpdated = now)
+          }
+
+      _stats.value = adjusted
+
+      if (!sameDay) {
+        scope.launch { persistStats(adjusted, currentUser.uid) }
+      }
+    }
+  }
+
+  override suspend fun addStudyMinutes(extraMinutes: Int) {
+    if (extraMinutes <= 0) {
+      return
+    }
+
+    val currentUser = auth.currentUser ?: return
+    val now = System.currentTimeMillis()
+    val current = _stats.value
+
+    val sameDay =
+        if (current.lastUpdated == DEFAULT_LONG_VALUE) {
+          true
+        } else {
+          isSameDay(current.lastUpdated, now)
+        }
+
+    val baseToday =
+        if (sameDay) {
+          current.todayStudyMinutes
+        } else {
+          DEFAULT_INT_VALUE
+        }
+
+    val updated =
+        current.copy(
+            totalStudyMinutes = current.totalStudyMinutes + extraMinutes,
+            todayStudyMinutes = baseToday + extraMinutes,
+            lastUpdated = now)
+
+    _stats.value = updated
+    persistStats(updated, currentUser.uid)
+  }
+
+  override suspend fun updateCoins(delta: Int) {
+    if (delta == 0) {
+      return
+    }
+
+    val currentUser = auth.currentUser ?: return
+    val now = System.currentTimeMillis()
+    val current = _stats.value
+
+    val updated = current.copy(coins = current.coins + delta, lastUpdated = now)
+
+    _stats.value = updated
+    persistStats(updated, currentUser.uid)
+  }
+
+  override suspend fun setWeeklyGoal(goalMinutes: Int) {
+    val currentUser = auth.currentUser ?: return
+    val now = System.currentTimeMillis()
+    val current = _stats.value
+
+    val updated = current.copy(weeklyGoal = goalMinutes, lastUpdated = now)
+
+    _stats.value = updated
+    persistStats(updated, currentUser.uid)
+  }
+
+  override suspend fun addPoints(delta: Int) {
+    if (delta == 0) {
+      return
+    }
+
+    val currentUser = auth.currentUser ?: return
+    val now = System.currentTimeMillis()
+    val current = _stats.value
+
+    val updated = current.copy(points = current.points + delta, lastUpdated = now)
+
+    _stats.value = updated
+    persistStats(updated, currentUser.uid)
+  }
+
+  private suspend fun ensureDefaultDocument(uid: String) {
+    val now = System.currentTimeMillis()
+    val defaults = UserStats(lastUpdated = now)
+    persistStats(defaults, uid)
+    _stats.value = defaults
+  }
+
+  private fun Map<String, Any>.toUserStats(): UserStats {
+    return UserStats(
+        totalStudyMinutes =
+            (this[FIELD_TOTAL_STUDY_MINUTES] as? Number)?.toInt() ?: DEFAULT_INT_VALUE,
+        todayStudyMinutes =
+            (this[FIELD_TODAY_STUDY_MINUTES] as? Number)?.toInt() ?: DEFAULT_INT_VALUE,
+        streak = (this[FIELD_STREAK] as? Number)?.toInt() ?: DEFAULT_INT_VALUE,
+        weeklyGoal = (this[FIELD_WEEKLY_GOAL] as? Number)?.toInt() ?: DEFAULT_INT_VALUE,
+        coins = (this[FIELD_COINS] as? Number)?.toInt() ?: DEFAULT_INT_VALUE,
+        points = (this[FIELD_POINTS] as? Number)?.toInt() ?: DEFAULT_INT_VALUE,
+        lastUpdated = (this[FIELD_LAST_UPDATED] as? Number)?.toLong() ?: DEFAULT_LONG_VALUE)
+  }
+
+  private fun userStatsToMap(stats: UserStats): Map<String, Any> {
+    return mapOf(
+        FIELD_TOTAL_STUDY_MINUTES to stats.totalStudyMinutes,
+        FIELD_TODAY_STUDY_MINUTES to stats.todayStudyMinutes,
+        FIELD_STREAK to stats.streak,
+        FIELD_WEEKLY_GOAL to stats.weeklyGoal,
+        FIELD_COINS to stats.coins,
+        FIELD_POINTS to stats.points,
+        FIELD_LAST_UPDATED to stats.lastUpdated)
+  }
+
+  private fun isSameDay(firstMillis: Long, secondMillis: Long): Boolean {
+    val cal1 = Calendar.getInstance(TimeZone.getDefault()).apply { timeInMillis = firstMillis }
+    val cal2 = Calendar.getInstance(TimeZone.getDefault()).apply { timeInMillis = secondMillis }
+
+    val year1 = cal1.get(Calendar.YEAR)
+    val year2 = cal2.get(Calendar.YEAR)
+    if (year1 != year2) {
+      return false
+    }
+
+    val day1 = cal1.get(Calendar.DAY_OF_YEAR)
+    val day2 = cal2.get(Calendar.DAY_OF_YEAR)
+    return day1 == day2
+  }
+
+  private fun persistStats(stats: UserStats, uid: String) {
+    val docRef =
+        firestore
+            .collection(USERS_COLLECTION)
+            .document(uid)
+            .collection(STATS_COLLECTION)
+            .document(STATS_DOCUMENT_ID)
+
+    val payload = userStatsToMap(stats)
+    docRef.set(payload, SetOptions.merge())
+  }
+}

--- a/app/src/main/java/com/android/sample/data/UserStats.kt
+++ b/app/src/main/java/com/android/sample/data/UserStats.kt
@@ -1,0 +1,14 @@
+package com.android.sample.data
+
+// This code has been written partially using A.I (LLM).
+
+/** Global user statistics stored in a single Firestore document: /users/{uid}/stats/stats */
+data class UserStats(
+    val totalStudyMinutes: Int = 0,
+    val todayStudyMinutes: Int = 0,
+    val streak: Int = 0,
+    val weeklyGoal: Int = 0,
+    val coins: Int = 0,
+    val points: Int = 0,
+    val lastUpdated: Long = 0L
+)

--- a/app/src/main/java/com/android/sample/data/UserStatsRepository.kt
+++ b/app/src/main/java/com/android/sample/data/UserStatsRepository.kt
@@ -1,0 +1,32 @@
+package com.android.sample.data
+
+// This code has been written partially using A.I (LLM).
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Repository abstraction for the unified user stats document. This will be used by Home, Profile,
+ * StudySession, Stats in PR2.
+ */
+interface UserStatsRepository {
+
+  val stats: StateFlow<UserStats>
+
+  /** Start listening to Firestore realtime updates for /users/{uid}/stats/stats. */
+  fun start()
+
+  /**
+   * Add study minutes to the global counters. Implementations must handle daily reset for
+   * todayStudyMinutes.
+   */
+  suspend fun addStudyMinutes(extraMinutes: Int)
+
+  /** Update coin balance by a delta (can be negative). */
+  suspend fun updateCoins(delta: Int)
+
+  /** Set the weekly goal (in minutes). */
+  suspend fun setWeeklyGoal(goalMinutes: Int)
+
+  /** Add points (e.g. on Pomodoro completion). */
+  suspend fun addPoints(delta: Int)
+}

--- a/app/src/main/java/com/android/sample/repos_providors/FakeRepositoriesProvider.kt
+++ b/app/src/main/java/com/android/sample/repos_providors/FakeRepositoriesProvider.kt
@@ -1,5 +1,9 @@
 package com.android.sample.repos_providors
 
+// This code has been written partially using A.I (LLM).
+
+import com.android.sample.data.FakeUserStatsRepository
+import com.android.sample.data.UserStatsRepository
 import com.android.sample.feature.homeScreen.FakeHomeRepository
 import com.android.sample.feature.homeScreen.HomeRepository
 import com.android.sample.feature.schedule.repository.calendar.CalendarRepositoryImpl
@@ -22,9 +26,12 @@ import com.android.sample.ui.stats.repository.StatsRepository
 
 /** Provider of in-memory fake repositories (no Firebase). */
 object FakeRepositoriesProvider : RepositoriesProvider {
+
   override val objectivesRepository: ObjectivesRepository = FakeObjectivesRepository
   override val weeksRepository: WeeksRepository = FakeWeeksRepository()
   override val statsRepository: StatsRepository = FakeStatsRepository()
+
+  override val userStatsRepository: UserStatsRepository = FakeUserStatsRepository()
 
   override val plannerRepository: PlannerRepository = PlannerRepository()
   override val studySessionRepository: StudySessionRepository = ToDoBackedStudySessionRepository()

--- a/app/src/main/java/com/android/sample/repos_providors/FirestoreRepositoriesProvider.kt
+++ b/app/src/main/java/com/android/sample/repos_providors/FirestoreRepositoriesProvider.kt
@@ -1,5 +1,9 @@
 package com.android.sample.repos_providors
 
+// This code has been written partially using A.I (LLM).
+
+import com.android.sample.data.FirestoreUserStatsRepository
+import com.android.sample.data.UserStatsRepository
 import com.android.sample.feature.homeScreen.FakeHomeRepository
 import com.android.sample.feature.homeScreen.HomeRepository
 import com.android.sample.feature.schedule.repository.calendar.CalendarRepositoryImpl
@@ -33,17 +37,26 @@ object FirestoreRepositoriesProvider : RepositoriesProvider {
   override val objectivesRepository: ObjectivesRepository by lazy {
     FirestoreObjectivesRepository(db, auth)
   }
+
   override val weeksRepository: WeeksRepository by lazy { FirestoreWeeksRepository(db, auth) }
+
   override val statsRepository: StatsRepository by lazy { FirestoreStatsRepository(db, auth) }
 
+  override val userStatsRepository: UserStatsRepository by lazy {
+    FirestoreUserStatsRepository(auth, db)
+  }
+
   override val friendRepository: FriendRepository by lazy { ProfilesFriendRepository(db, auth) }
+
   override val flashcardsRepository: FlashcardsRepository by lazy {
     FirestoreFlashcardsRepository(db, auth)
   }
 
   // Local implementations until remote backends exist
   override val homeRepository: HomeRepository by lazy { FakeHomeRepository() }
+
   override val plannerRepository: PlannerRepoForPlanner by lazy { PlannerRepoForPlanner() }
+
   override val studySessionRepository: StudySessionRepository by lazy {
     ToDoBackedStudySessionRepository()
   }
@@ -51,6 +64,7 @@ object FirestoreRepositoriesProvider : RepositoriesProvider {
   override val calendarRepository: CalendarRepositoryImpl by lazy { CalendarRepositoryImpl() }
 
   override val toDoRepository: ToDoRepository by lazy { ToDoRepositoryLocal() }
+
   override val profileRepository: ProfileRepository by lazy { FakeProfileRepository() }
 }
 

--- a/app/src/main/java/com/android/sample/repos_providors/RepositoriesProvider.kt
+++ b/app/src/main/java/com/android/sample/repos_providors/RepositoriesProvider.kt
@@ -1,5 +1,8 @@
 package com.android.sample.repos_providors
 
+// This code has been written partially using A.I (LLM).
+
+import com.android.sample.data.UserStatsRepository
 import com.android.sample.feature.homeScreen.HomeRepository
 import com.android.sample.feature.schedule.repository.calendar.CalendarRepositoryImpl
 import com.android.sample.feature.schedule.repository.planner.PlannerRepository
@@ -20,9 +23,13 @@ import com.android.sample.ui.stats.repository.StatsRepository
  * - FirestoreRepositoriesProvider (Firebase-backed)
  */
 interface RepositoriesProvider {
+
   val objectivesRepository: ObjectivesRepository
   val weeksRepository: WeeksRepository
   val statsRepository: StatsRepository
+
+  // Unified user stats (Firestore document /users/{uid}/stats/stats)
+  val userStatsRepository: UserStatsRepository
 
   // Home / Planner (attendance) / Study Session
   val homeRepository: HomeRepository

--- a/app/src/test/java/com/android/sample/data/FakeUserStatsRepositoryTest.kt
+++ b/app/src/test/java/com/android/sample/data/FakeUserStatsRepositoryTest.kt
@@ -1,0 +1,108 @@
+package com.android.sample.data
+
+// This code has been written partially using A.I (LLM).
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FakeUserStatsRepositoryTest {
+
+  @Test
+  fun initial_state_is_default() = runTest {
+    val repo = FakeUserStatsRepository()
+
+    val stats = repo.stats.value
+
+    assertEquals(0, stats.totalStudyMinutes)
+    assertEquals(0, stats.todayStudyMinutes)
+    assertEquals(0, stats.coins)
+    assertEquals(0, stats.points)
+    assertEquals(0, stats.weeklyGoal)
+    assertEquals(0L, stats.lastUpdated)
+  }
+
+  @Test
+  fun addStudyMinutes_positive_updates_total_and_today() = runTest {
+    val repo = FakeUserStatsRepository()
+
+    repo.addStudyMinutes(30)
+
+    val stats = repo.stats.value
+    assertEquals(30, stats.totalStudyMinutes)
+    assertEquals(30, stats.todayStudyMinutes)
+  }
+
+  @Test
+  fun addStudyMinutes_nonPositive_does_not_change_state() = runTest {
+    val repo = FakeUserStatsRepository(UserStats(totalStudyMinutes = 10, todayStudyMinutes = 5))
+
+    repo.addStudyMinutes(0)
+    repo.addStudyMinutes(-10)
+
+    val stats = repo.stats.value
+    assertEquals(10, stats.totalStudyMinutes)
+    assertEquals(5, stats.todayStudyMinutes)
+  }
+
+  @Test
+  fun updateCoins_updates_only_coins_when_nonZero() = runTest {
+    val repo = FakeUserStatsRepository(UserStats(coins = 4))
+
+    repo.updateCoins(3)
+
+    val stats = repo.stats.value
+    assertEquals(7, stats.coins)
+  }
+
+  @Test
+  fun updateCoins_zero_does_nothing() = runTest {
+    val repo = FakeUserStatsRepository(UserStats(coins = 4))
+
+    repo.updateCoins(0)
+
+    val stats = repo.stats.value
+    assertEquals(4, stats.coins)
+  }
+
+  @Test
+  fun setWeeklyGoal_updates_weeklyGoal() = runTest {
+    val repo = FakeUserStatsRepository(UserStats(weeklyGoal = 100))
+
+    repo.setWeeklyGoal(250)
+
+    val stats = repo.stats.value
+    assertEquals(250, stats.weeklyGoal)
+  }
+
+  @Test
+  fun addPoints_updates_points_when_nonZero() = runTest {
+    val repo = FakeUserStatsRepository(UserStats(points = 10))
+
+    repo.addPoints(5)
+
+    val stats = repo.stats.value
+    assertEquals(15, stats.points)
+  }
+
+  @Test
+  fun addPoints_zero_does_not_change_points() = runTest {
+    val repo = FakeUserStatsRepository(UserStats(points = 10))
+
+    repo.addPoints(0)
+
+    val stats = repo.stats.value
+    assertEquals(10, stats.points)
+  }
+
+  @Test
+  fun start_does_not_throw_and_keeps_state() {
+    val initial = UserStats(totalStudyMinutes = 42)
+    val repo = FakeUserStatsRepository(initial)
+
+    repo.start()
+
+    val stats = repo.stats.value
+    assertEquals(42, stats.totalStudyMinutes)
+  }
+}

--- a/app/src/test/java/com/android/sample/data/FirestoreUserStatsRepositoryTest.kt
+++ b/app/src/test/java/com/android/sample/data/FirestoreUserStatsRepositoryTest.kt
@@ -1,0 +1,258 @@
+package com.android.sample.data
+
+// This code has been written partially using A.I (LLM).
+
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.FirebaseFirestore
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.util.Calendar
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class FirestoreUserStatsRepositoryTest {
+
+  private lateinit var auth: FirebaseAuth
+  private lateinit var firestore: FirebaseFirestore
+  private lateinit var user: FirebaseUser
+  private lateinit var usersCollection: CollectionReference
+  private lateinit var statsCollection: CollectionReference
+  private lateinit var statsDoc: DocumentReference
+
+  @Before
+  fun setup() {
+    auth = mock(FirebaseAuth::class.java)
+    firestore = mock(FirebaseFirestore::class.java)
+    user = mock(FirebaseUser::class.java)
+    usersCollection = mock(CollectionReference::class.java)
+    statsCollection = mock(CollectionReference::class.java)
+    statsDoc = mock(DocumentReference::class.java)
+
+    `when`(auth.currentUser).thenReturn(user)
+    `when`(user.uid).thenReturn("test-uid")
+
+    `when`(firestore.collection("users")).thenReturn(usersCollection)
+    `when`(usersCollection.document("test-uid")).thenReturn(statsDoc)
+    `when`(statsDoc.collection("stats")).thenReturn(statsCollection)
+    `when`(statsCollection.document("stats")).thenReturn(statsDoc)
+  }
+
+  private fun createRepo(): FirestoreUserStatsRepository =
+      FirestoreUserStatsRepository(auth, firestore)
+
+  // Helper to inject _stats private field for branch coverage
+  private fun setInternalStats(repo: FirestoreUserStatsRepository, stats: UserStats) {
+    val field: Field =
+        FirestoreUserStatsRepository::class.java.getDeclaredField("_stats").apply {
+          isAccessible = true
+        }
+    @Suppress("UNCHECKED_CAST") val flow = field.get(repo) as MutableStateFlow<UserStats>
+    flow.value = stats
+  }
+
+  @Test
+  fun initial_state_is_default_without_start() {
+    val repo = createRepo()
+
+    val stats = repo.stats.value
+
+    assertEquals(0, stats.totalStudyMinutes)
+    assertEquals(0, stats.todayStudyMinutes)
+    assertEquals(0, stats.coins)
+    assertEquals(0, stats.points)
+    assertEquals(0, stats.weeklyGoal)
+    assertEquals(0L, stats.lastUpdated)
+  }
+
+  @Test
+  fun start_with_no_current_user_does_not_crash_and_does_not_change_stats() {
+    `when`(auth.currentUser).thenReturn(null)
+    val repo = createRepo()
+
+    repo.start()
+
+    val stats = repo.stats.value
+    assertEquals(UserStats(), stats)
+  }
+
+  @Test
+  fun addStudyMinutes_same_day_increments_total_and_today() = runTest {
+    val repo = createRepo()
+
+    val initial =
+        UserStats(
+            totalStudyMinutes = 10, todayStudyMinutes = 4, lastUpdated = 0L // treated as "same day"
+            )
+    setInternalStats(repo, initial)
+
+    repo.addStudyMinutes(20)
+
+    val updated = repo.stats.value
+    assertEquals(30, updated.totalStudyMinutes)
+    assertEquals(24, updated.todayStudyMinutes)
+    assertTrue(updated.lastUpdated > 0L)
+  }
+
+  @Test
+  fun addStudyMinutes_cross_day_resets_today_and_keeps_total_plus_extra() = runTest {
+    val repo = createRepo()
+
+    val calendar = Calendar.getInstance()
+    calendar.add(Calendar.DAY_OF_YEAR, -1)
+    val yesterdayMillis = calendar.timeInMillis
+
+    val initial =
+        UserStats(totalStudyMinutes = 100, todayStudyMinutes = 40, lastUpdated = yesterdayMillis)
+    setInternalStats(repo, initial)
+
+    repo.addStudyMinutes(25)
+
+    val updated = repo.stats.value
+    assertEquals(125, updated.totalStudyMinutes)
+    assertEquals(25, updated.todayStudyMinutes)
+    assertTrue(updated.lastUpdated > yesterdayMillis)
+  }
+
+  @Test
+  fun addStudyMinutes_non_positive_does_not_change_stats() = runTest {
+    val repo = createRepo()
+    val initial = UserStats(totalStudyMinutes = 50, todayStudyMinutes = 20, lastUpdated = 1234L)
+    setInternalStats(repo, initial)
+
+    repo.addStudyMinutes(0)
+
+    val updated = repo.stats.value
+    assertEquals(initial, updated)
+  }
+
+  @Test
+  fun updateCoins_positive_delta_updates_and_sets_lastUpdated() = runTest {
+    val repo = createRepo()
+    val initial = UserStats(coins = 10, lastUpdated = 10L)
+    setInternalStats(repo, initial)
+
+    repo.updateCoins(5)
+
+    val updated = repo.stats.value
+    assertEquals(15, updated.coins)
+    assertTrue(updated.lastUpdated >= initial.lastUpdated)
+  }
+
+  @Test
+  fun updateCoins_zero_does_not_change_state() = runTest {
+    val repo = createRepo()
+    val initial = UserStats(coins = 10, lastUpdated = 100L)
+    setInternalStats(repo, initial)
+
+    repo.updateCoins(0)
+
+    val updated = repo.stats.value
+    assertEquals(initial, updated)
+  }
+
+  @Test
+  fun setWeeklyGoal_updates_field_and_lastUpdated() = runTest {
+    val repo = createRepo()
+    val initial = UserStats(weeklyGoal = 100, lastUpdated = 10L)
+    setInternalStats(repo, initial)
+
+    repo.setWeeklyGoal(300)
+
+    val updated = repo.stats.value
+    assertEquals(300, updated.weeklyGoal)
+    assertTrue(updated.lastUpdated >= initial.lastUpdated)
+  }
+
+  @Test
+  fun addPoints_positive_updates_points_and_lastUpdated() = runTest {
+    val repo = createRepo()
+    val initial = UserStats(points = 5, lastUpdated = 10L)
+    setInternalStats(repo, initial)
+
+    repo.addPoints(7)
+
+    val updated = repo.stats.value
+    assertEquals(12, updated.points)
+    assertTrue(updated.lastUpdated >= initial.lastUpdated)
+  }
+
+  @Test
+  fun addPoints_zero_does_not_change_state() = runTest {
+    val repo = createRepo()
+    val initial = UserStats(points = 5, lastUpdated = 10L)
+    setInternalStats(repo, initial)
+
+    repo.addPoints(0)
+
+    val updated = repo.stats.value
+    assertEquals(initial, updated)
+  }
+
+  @Test
+  fun userStatsToMap_and_toUserStats_are_inverse_for_typical_values() {
+    val repo = createRepo()
+    val stats =
+        UserStats(
+            totalStudyMinutes = 120,
+            todayStudyMinutes = 45,
+            streak = 3,
+            weeklyGoal = 300,
+            coins = 50,
+            points = 80,
+            lastUpdated = 9999L)
+
+    val toMapMethod: Method =
+        FirestoreUserStatsRepository::class
+            .java
+            .getDeclaredMethod("userStatsToMap", UserStats::class.java)
+    toMapMethod.isAccessible = true
+    @Suppress("UNCHECKED_CAST") val map = toMapMethod.invoke(repo, stats) as Map<String, Any>
+
+    val toUserStatsMethod: Method =
+        FirestoreUserStatsRepository::class.java.getDeclaredMethod("toUserStats", Map::class.java)
+    toUserStatsMethod.isAccessible = true
+    val reconstructed = toUserStatsMethod.invoke(repo, map) as UserStats
+
+    assertEquals(stats.totalStudyMinutes, reconstructed.totalStudyMinutes)
+    assertEquals(stats.todayStudyMinutes, reconstructed.todayStudyMinutes)
+    assertEquals(stats.streak, reconstructed.streak)
+    assertEquals(stats.weeklyGoal, reconstructed.weeklyGoal)
+    assertEquals(stats.coins, reconstructed.coins)
+    assertEquals(stats.points, reconstructed.points)
+    assertEquals(stats.lastUpdated, reconstructed.lastUpdated)
+  }
+
+  @Test
+  fun isSameDay_returns_true_for_same_calendar_day_and_false_otherwise() {
+    val repo = createRepo()
+
+    val method: Method =
+        FirestoreUserStatsRepository::class
+            .java
+            .getDeclaredMethod(
+                "isSameDay", Long::class.javaPrimitiveType, Long::class.javaPrimitiveType)
+    method.isAccessible = true
+
+    val cal = Calendar.getInstance()
+    val t1 = cal.timeInMillis
+    cal.add(Calendar.HOUR_OF_DAY, 1)
+    val t2 = cal.timeInMillis
+    cal.add(Calendar.DAY_OF_YEAR, 1)
+    val nextDay = cal.timeInMillis
+
+    val sameDayResult = method.invoke(repo, t1, t2) as Boolean
+    val differentDayResult = method.invoke(repo, t1, nextDay) as Boolean
+
+    assertTrue(sameDayResult)
+    assertEquals(false, differentDayResult)
+  }
+}


### PR DESCRIPTION
## Summary
Create a single canonical Firestore document for user statistics to eliminate duplicated logic and inconsistent data across the app, now there is a single source of truth for the user stats across all the app, and also on Firestore.

## What’s in this PR

- New UserStats model and UserStatsRepository interface.
- FirestoreUserStatsRepository using /users/{uid}/stats/stats.
- Daily-reset logic via snapshot listener (todayStudyMinutes reset when day changes).
- Default seeding (ensureDefaultDocument).
- Fake in-memory implementation for tests.
- Full test suite covering mapping, day-change behavior, snapshot handling, and all public methods.

## Implementation Notes

- Single document = simpler reads/writes and no multi-collection inconsistencies.
- Snapshot listener ensures stats always stay synced and auto-reset.
- Writes use merge=true and run on an IO coroutine scope.
- No Firestore indexes required.

## Testing

**Unit tests cover:**

- initial state, missing user, same-day vs cross-day updates
- addStudyMinutes, updateCoins, setWeeklyGoal, addPoints
- ensureDefaultDocument
- snapshot listener logic
- mapping helpers & isSameDay

No UI tests for this PR.

## Screenshots / Demos

<img width="1524" height="523" alt="image" src="https://github.com/user-attachments/assets/a8eb44d8-6ce5-43f0-bd7c-f191ebb813de" /> 
<img width="693" height="181" alt="image" src="https://github.com/user-attachments/assets/23c53537-0d11-4716-a52c-a754ac65ea45" />

## Checklist
- [x] A UserStatsRepository connects to /users/{uid}/stats.
- [x] Fields: totalStudyMinutes, streak, weeklyGoal, coins, lastUpdated.


## Notes
The help of an A.I assistant has been used to generate parts of this PR and parts of the code.

## Issue Reference
Closes #166 

