### PR TITLE
feat: unify EduMon rendering across all app screens

### DIFF
--- a/app/src/androidTest/java/com/android/sample/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/HomeScreenTest.kt
@@ -96,7 +96,7 @@ class HomeScreenTest {
         .onNodeWithContentDescription("Creature environment")
         .performScrollTo()
         .assertExists()
-    composeRule.onNodeWithContentDescription("Creature").performScrollTo().assertExists()
+
     composeRule.onNodeWithText("Lv 5").performScrollTo().assertIsDisplayed()
   }
 

--- a/app/src/androidTest/java/com/android/sample/ui/profile/EduMonAvatarTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/profile/EduMonAvatarTest.kt
@@ -1,0 +1,287 @@
+package com.android.sample.ui.profile
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.dp
+import com.android.sample.data.AccessorySlot
+import com.android.sample.data.UserProfile
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class EduMonAvatarTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var testViewModel: TestProfileViewModel
+
+  @Before
+  fun setup() {
+    testViewModel = TestProfileViewModel()
+  }
+
+  @Test
+  fun eduMonAvatar_displaysCorrectly_withDefaultParameters() {
+    composeTestRule.setContent {
+      EduMonAvatar(
+          modifier = androidx.compose.ui.Modifier.testTag("avatar_root"), viewModel = testViewModel)
+    }
+
+    composeTestRule.onNodeWithTag("avatar_root").assertExists().assertIsDisplayed()
+
+    composeTestRule.onNodeWithText("Level 5").assertExists().assertIsDisplayed()
+  }
+
+  @Test
+  fun eduMonAvatar_displaysCorrectly_withoutLevelLabel() {
+    composeTestRule.setContent {
+      EduMonAvatar(
+          modifier = androidx.compose.ui.Modifier.testTag("avatar_root"),
+          viewModel = testViewModel,
+          showLevelLabel = false)
+    }
+
+    composeTestRule.onNodeWithTag("avatar_root").assertExists().assertIsDisplayed()
+
+    composeTestRule.onNodeWithText("Level 5").assertDoesNotExist()
+  }
+
+  @Test
+  fun eduMonAvatar_displaysCorrectLevel_whenUserLevelChanges() {
+    composeTestRule.setContent { EduMonAvatar(viewModel = testViewModel) }
+
+    composeTestRule.onNodeWithText("Level 5").assertExists()
+
+    testViewModel.updateUserLevel(10)
+
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithText("Level 10").assertExists()
+  }
+
+  @Test
+  fun eduMonAvatar_usesCustomAvatarSize() {
+    val customSize = 200.dp
+
+    composeTestRule.setContent {
+      EduMonAvatar(
+          modifier = androidx.compose.ui.Modifier.testTag("avatar_root"),
+          viewModel = testViewModel,
+          avatarSize = customSize)
+    }
+
+    composeTestRule.onNodeWithTag("avatar_root").assertExists().assertIsDisplayed()
+  }
+
+  @Test
+  fun eduMonAvatar_displaysBackAccessory_whenEquipped() {
+    testViewModel.updateAccessories(listOf("back:wings"))
+
+    composeTestRule.setContent { EduMonAvatar(viewModel = testViewModel) }
+
+    composeTestRule.waitForIdle()
+
+    assert(
+        testViewModel.accessoryResIdCalls.any {
+          it.first == AccessorySlot.BACK && it.second == "wings"
+        })
+  }
+
+  @Test
+  fun eduMonAvatar_displaysTorsoAccessory_whenEquipped() {
+    testViewModel.updateAccessories(listOf("torso:shirt"))
+
+    composeTestRule.setContent { EduMonAvatar(viewModel = testViewModel) }
+
+    composeTestRule.waitForIdle()
+
+    assert(
+        testViewModel.accessoryResIdCalls.any {
+          it.first == AccessorySlot.TORSO && it.second == "shirt"
+        })
+  }
+
+  @Test
+  fun eduMonAvatar_displaysHeadAccessory_whenEquipped() {
+    testViewModel.updateAccessories(listOf("head:hat"))
+
+    composeTestRule.setContent { EduMonAvatar(viewModel = testViewModel) }
+
+    composeTestRule.waitForIdle()
+
+    assert(
+        testViewModel.accessoryResIdCalls.any {
+          it.first == AccessorySlot.HEAD && it.second == "hat"
+        })
+  }
+
+  @Test
+  fun eduMonAvatar_displaysMultipleAccessories_whenEquipped() {
+    testViewModel.updateAccessories(listOf("back:wings", "torso:shirt", "head:hat"))
+
+    composeTestRule.setContent { EduMonAvatar(viewModel = testViewModel) }
+
+    composeTestRule.waitForIdle()
+
+    assert(
+        testViewModel.accessoryResIdCalls.any {
+          it.first == AccessorySlot.BACK && it.second == "wings"
+        })
+    assert(
+        testViewModel.accessoryResIdCalls.any {
+          it.first == AccessorySlot.TORSO && it.second == "shirt"
+        })
+    assert(
+        testViewModel.accessoryResIdCalls.any {
+          it.first == AccessorySlot.HEAD && it.second == "hat"
+        })
+  }
+
+  @Test
+  fun eduMonAvatar_ignoresInvalidAccessoryFormat() {
+    testViewModel.updateAccessories(listOf("invalid", "back:wings", "also_invalid"))
+
+    composeTestRule.setContent { EduMonAvatar(viewModel = testViewModel) }
+
+    composeTestRule.waitForIdle()
+
+    val backCalls =
+        testViewModel.accessoryResIdCalls.count {
+          it.first == AccessorySlot.BACK && it.second == "wings"
+        }
+    assert(backCalls == 1)
+  }
+
+  @Test
+  fun eduMonAvatar_doesNotDisplayAccessory_whenResourceIdIsZero() {
+    testViewModel.updateAccessories(listOf("back:wings"))
+    testViewModel.shouldReturnZeroResId = true
+
+    composeTestRule.setContent {
+      EduMonAvatar(
+          modifier = androidx.compose.ui.Modifier.testTag("avatar_root"), viewModel = testViewModel)
+    }
+
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag("avatar_root").assertExists()
+  }
+
+  @Test
+  fun eduMonAvatar_updatesAccentColor_whenAccentEffectiveChanges() {
+    composeTestRule.setContent {
+      EduMonAvatar(
+          modifier = androidx.compose.ui.Modifier.testTag("avatar_root"), viewModel = testViewModel)
+    }
+
+    testViewModel.updateAccentColor(Color.Red)
+
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag("avatar_root").assertExists().assertIsDisplayed()
+  }
+
+  @Test
+  fun eduMonAvatar_handlesEmptyAccessoriesList() {
+    testViewModel.updateAccessories(emptyList())
+
+    composeTestRule.setContent {
+      EduMonAvatar(
+          modifier = androidx.compose.ui.Modifier.testTag("avatar_root"), viewModel = testViewModel)
+    }
+
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag("avatar_root").assertExists().assertIsDisplayed()
+
+    assert(testViewModel.accessoryResIdCalls.isEmpty())
+  }
+
+  @Test
+  fun eduMonAvatar_appliesCustomModifier() {
+    composeTestRule.setContent {
+      EduMonAvatar(
+          modifier = androidx.compose.ui.Modifier.testTag("custom_avatar"),
+          viewModel = testViewModel)
+    }
+
+    composeTestRule.onNodeWithTag("custom_avatar").assertExists()
+  }
+
+  @Test
+  fun eduMonAvatar_handlesAccessoriesWithColonInId() {
+    testViewModel.updateAccessories(listOf("back:special:wings:v2"))
+
+    composeTestRule.setContent { EduMonAvatar(viewModel = testViewModel) }
+
+    composeTestRule.waitForIdle()
+
+    assert(testViewModel.accessoryResIdCalls.isEmpty())
+  }
+
+  @Test
+  fun eduMonAvatar_usesCorrectZIndexForAccessories() {
+    testViewModel.updateAccessories(listOf("back:wings", "torso:shirt", "head:hat"))
+
+    composeTestRule.setContent { EduMonAvatar(viewModel = testViewModel) }
+
+    composeTestRule.waitForIdle()
+
+    val calls = testViewModel.accessoryResIdCalls
+    assert(calls.size >= 3)
+
+    val backIndex = calls.indexOfFirst { it.first == AccessorySlot.BACK }
+    val torsoIndex = calls.indexOfFirst { it.first == AccessorySlot.TORSO }
+    val headIndex = calls.indexOfFirst { it.first == AccessorySlot.HEAD }
+
+    assert(backIndex < torsoIndex)
+    assert(torsoIndex < headIndex)
+  }
+
+  @Test
+  fun eduMonAvatar_handlesNullContentDescription() {
+    testViewModel.updateAccessories(listOf("back:wings"))
+
+    composeTestRule.setContent {
+      EduMonAvatar(
+          modifier = androidx.compose.ui.Modifier.testTag("avatar_root"), viewModel = testViewModel)
+    }
+
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag("avatar_root").assertExists()
+  }
+}
+
+class TestProfileViewModel : ProfileViewModel() {
+  private val _userProfile = MutableStateFlow(UserProfile(level = 5, accessories = emptyList()))
+  override val userProfile: StateFlow<UserProfile> = _userProfile
+
+  private val _accentEffective = MutableStateFlow(Color.Blue)
+  override val accentEffective: StateFlow<Color> = _accentEffective
+
+  val accessoryResIdCalls = mutableListOf<Pair<AccessorySlot, String>>()
+  var shouldReturnZeroResId = false
+
+  override fun accessoryResId(slot: AccessorySlot, id: String): Int {
+    accessoryResIdCalls.add(slot to id)
+    return if (shouldReturnZeroResId) 0 else android.R.drawable.ic_menu_gallery
+  }
+
+  fun updateUserLevel(newLevel: Int) {
+    _userProfile.value = _userProfile.value.copy(level = newLevel)
+  }
+
+  fun updateAccessories(newAccessories: List<String>) {
+    _userProfile.value = _userProfile.value.copy(accessories = newAccessories)
+    accessoryResIdCalls.clear()
+  }
+
+  fun updateAccentColor(newColor: Color) {
+    _accentEffective.value = newColor
+  }
+}

--- a/app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTest.kt
@@ -7,7 +7,6 @@ import androidx.compose.material3.Text
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import com.android.sample.data.AccentVariant
 import com.android.sample.data.AccessoryItem
 import com.android.sample.data.AccessorySlot
 import com.android.sample.data.Rarity
@@ -77,34 +76,12 @@ class ProfileScreenTest {
   @Test
   fun petSectionDisplaysAllElements() {
     val vm = ProfileViewModel(FakeProfileRepository())
-    composeRule.setContent {
-      PetSection(
-          level = 5,
-          accent = Color.Magenta,
-          accessories = listOf("head:wizard_hat", "torso:cape", "back:wings"),
-          variant = AccentVariant.Base,
-          viewModel = vm)
-    }
+    composeRule.setContent { PetSection(viewModel = vm) }
 
     composeRule.onNodeWithText("Level 5").assertExists()
     composeRule.onNodeWithText("90%").assertExists()
     composeRule.onNodeWithText("85%").assertExists()
     composeRule.onNodeWithText("70%").assertExists()
-  }
-
-  @Test
-  fun petSectionWithEmptyAccessories() {
-    val vm = ProfileViewModel(FakeProfileRepository())
-    composeRule.setContent {
-      PetSection(
-          level = 1,
-          accent = Color.Blue,
-          accessories = emptyList(),
-          variant = AccentVariant.Light,
-          viewModel = vm)
-    }
-
-    composeRule.onNodeWithText("Level 1").assertExists()
   }
 
   @Test
@@ -446,48 +423,10 @@ class ProfileScreenTest {
   }
 
   @Test
-  fun petSectionWithDifferentAccessorySlots() {
-    val vm = ProfileViewModel(FakeProfileRepository())
-
-    // Test head accessory
-    composeRule.setContent {
-      PetSection(
-          level = 3,
-          accent = Color.Cyan,
-          accessories = listOf("head:wizard_hat"),
-          variant = AccentVariant.Dark,
-          viewModel = vm)
-    }
-    composeRule.onNodeWithText("Level 3").assertExists()
-  }
-
-  @Test
-  fun petSectionWithTorsoAccessory() {
-    val vm = ProfileViewModel(FakeProfileRepository())
-
-    composeRule.setContent {
-      PetSection(
-          level = 4,
-          accent = Color.Green,
-          accessories = listOf("torso:cape"),
-          variant = AccentVariant.Vibrant,
-          viewModel = vm)
-    }
-    composeRule.onNodeWithText("Level 4").assertExists()
-  }
-
-  @Test
   fun petSectionWithBackAccessory() {
     val vm = ProfileViewModel(FakeProfileRepository())
 
-    composeRule.setContent {
-      PetSection(
-          level = 5,
-          accent = Color.Yellow,
-          accessories = listOf("back:wings"),
-          variant = AccentVariant.Base,
-          viewModel = vm)
-    }
+    composeRule.setContent { PetSection(viewModel = vm) }
     composeRule.onNodeWithText("Level 5").assertExists()
   }
 

--- a/app/src/main/java/com/android/sample/MainActivity.kt
+++ b/app/src/main/java/com/android/sample/MainActivity.kt
@@ -7,45 +7,105 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
+import androidx.compose.material3.*
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.android.sample.ui.login.LoginScreen
 import com.android.sample.ui.theme.EduMonTheme
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.google.firebase.auth.FirebaseAuth
 
 class MainActivity : ComponentActivity() {
+
+  private val auth: FirebaseAuth by lazy { FirebaseAuth.getInstance() }
 
   @OptIn(ExperimentalMaterial3Api::class)
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
+    // Capture the intent data (deep link) if present
     val startUri: Uri? = intent?.data
 
-    val startRoute =
+    // Compute start destination based on deep link
+    val (startRoute, _) =
         if (startUri?.scheme == "edumon" && startUri.host == "study_session") {
           val id = startUri.pathSegments.firstOrNull()
-          if (!id.isNullOrEmpty()) "study/$id"
-          else com.android.sample.feature.homeScreen.AppDestination.Home.route
-        } else {
-          com.android.sample.feature.homeScreen.AppDestination.Home.route
-        }
+          if (!id.isNullOrEmpty()) "study/$id" to id
+          else com.android.sample.feature.homeScreen.AppDestination.Home.route to null
+        } else com.android.sample.feature.homeScreen.AppDestination.Home.route to null
 
     setContent {
       EduMonTheme {
         val nav = rememberNavController()
+        var user by remember { mutableStateOf(auth.currentUser) }
+        val scope = rememberCoroutineScope()
 
-        Scaffold(topBar = { CenterAlignedTopAppBar(title = { Text("EduMon") }) }) { padding ->
-          Box(Modifier.fillMaxSize().padding(padding)) {
-            NavHost(navController = nav, startDestination = "app") {
-              composable("app") { EduMonNavHost(startDestination = startRoute) }
-            }
-          }
+        DisposableEffect(Unit) {
+          val l =
+              FirebaseAuth.AuthStateListener { fa ->
+                val u = fa.currentUser
+                val goTo = if (u == null) "login" else "app"
+                user = u
+                nav.navigate(goTo) {
+                  popUpTo(nav.graph.startDestinationId) { inclusive = true }
+                  launchSingleTop = true
+                }
+              }
+          auth.addAuthStateListener(l)
+          onDispose { auth.removeAuthStateListener(l) }
         }
+
+        Scaffold(
+            topBar = {
+              CenterAlignedTopAppBar(
+                  title = { Text(if (user == null) "EduMon — Connection " else "") },
+                  actions = {
+                    if (user != null) {
+                      TextButton(onClick = { signOutAll() }) { Text("Logout") }
+                    }
+                  })
+            }) { padding ->
+              Box(Modifier.fillMaxSize().padding(padding)) {
+                NavHost(
+                    navController = nav, startDestination = if (user == null) "login" else "app") {
+                      composable("login") {
+                        LoginScreen(
+                            onLoggedIn = {
+                              nav.navigate("app") {
+                                popUpTo("login") { inclusive = true }
+                                launchSingleTop = true
+                              }
+                            })
+                      }
+
+                      composable("app") {
+                        LaunchedEffect(user?.uid) { user?.let { try {} catch (_: Exception) {} } }
+                        EduMonNavHost(startDestination = startRoute)
+                      }
+                    }
+              }
+            }
       }
     }
+  }
+
+  private fun signOutAll() {
+    val gso =
+        GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+            .requestIdToken(getString(R.string.default_web_client_id))
+            .requestEmail()
+            .build()
+    val googleClient = GoogleSignIn.getClient(this, gso)
+    googleClient.revokeAccess().addOnCompleteListener { auth.signOut() }
   }
 }

--- a/app/src/main/java/com/android/sample/MainActivity.kt
+++ b/app/src/main/java/com/android/sample/MainActivity.kt
@@ -7,105 +7,45 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.*
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import com.android.sample.ui.login.LoginScreen
 import com.android.sample.ui.theme.EduMonTheme
-import com.google.android.gms.auth.api.signin.GoogleSignIn
-import com.google.android.gms.auth.api.signin.GoogleSignInOptions
-import com.google.firebase.auth.FirebaseAuth
 
 class MainActivity : ComponentActivity() {
-
-  private val auth: FirebaseAuth by lazy { FirebaseAuth.getInstance() }
 
   @OptIn(ExperimentalMaterial3Api::class)
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    // Capture the intent data (deep link) if present
     val startUri: Uri? = intent?.data
 
-    // Compute start destination based on deep link
-    val (startRoute, _) =
+    val startRoute =
         if (startUri?.scheme == "edumon" && startUri.host == "study_session") {
           val id = startUri.pathSegments.firstOrNull()
-          if (!id.isNullOrEmpty()) "study/$id" to id
-          else com.android.sample.feature.homeScreen.AppDestination.Home.route to null
-        } else com.android.sample.feature.homeScreen.AppDestination.Home.route to null
+          if (!id.isNullOrEmpty()) "study/$id"
+          else com.android.sample.feature.homeScreen.AppDestination.Home.route
+        } else {
+          com.android.sample.feature.homeScreen.AppDestination.Home.route
+        }
 
     setContent {
       EduMonTheme {
         val nav = rememberNavController()
-        var user by remember { mutableStateOf(auth.currentUser) }
-        val scope = rememberCoroutineScope()
 
-        DisposableEffect(Unit) {
-          val l =
-              FirebaseAuth.AuthStateListener { fa ->
-                val u = fa.currentUser
-                val goTo = if (u == null) "login" else "app"
-                user = u
-                nav.navigate(goTo) {
-                  popUpTo(nav.graph.startDestinationId) { inclusive = true }
-                  launchSingleTop = true
-                }
-              }
-          auth.addAuthStateListener(l)
-          onDispose { auth.removeAuthStateListener(l) }
-        }
-
-        Scaffold(
-            topBar = {
-              CenterAlignedTopAppBar(
-                  title = { Text(if (user == null) "EduMon — Connection " else "") },
-                  actions = {
-                    if (user != null) {
-                      TextButton(onClick = { signOutAll() }) { Text("Logout") }
-                    }
-                  })
-            }) { padding ->
-              Box(Modifier.fillMaxSize().padding(padding)) {
-                NavHost(
-                    navController = nav, startDestination = if (user == null) "login" else "app") {
-                      composable("login") {
-                        LoginScreen(
-                            onLoggedIn = {
-                              nav.navigate("app") {
-                                popUpTo("login") { inclusive = true }
-                                launchSingleTop = true
-                              }
-                            })
-                      }
-
-                      composable("app") {
-                        LaunchedEffect(user?.uid) { user?.let { try {} catch (_: Exception) {} } }
-                        EduMonNavHost(startDestination = startRoute)
-                      }
-                    }
-              }
+        Scaffold(topBar = { CenterAlignedTopAppBar(title = { Text("EduMon") }) }) { padding ->
+          Box(Modifier.fillMaxSize().padding(padding)) {
+            NavHost(navController = nav, startDestination = "app") {
+              composable("app") { EduMonNavHost(startDestination = startRoute) }
             }
+          }
+        }
       }
     }
-  }
-
-  private fun signOutAll() {
-    val gso =
-        GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-            .requestIdToken(getString(R.string.default_web_client_id))
-            .requestEmail()
-            .build()
-    val googleClient = GoogleSignIn.getClient(this, gso)
-    googleClient.revokeAccess().addOnCompleteListener { auth.signOut() }
   }
 }

--- a/app/src/main/java/com/android/sample/feature/homeScreen/HomeScreen.kt
+++ b/app/src/main/java/com/android/sample/feature/homeScreen/HomeScreen.kt
@@ -181,14 +181,13 @@ fun EduMonHomeScreen(
                       .verticalScroll(rememberScrollState())
                       .padding(horizontal = 16.dp, vertical = 8.dp),
                   verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                  CreatureHouseCard(
-                      creatureResId = creatureResId,
-                      level = state.creatureStats.level,
-                      environmentResId = environmentResId,
-                      overrideCreature = { EduMonAvatar(showLevelLabel = false) }
-                  )
+                    CreatureHouseCard(
+                        creatureResId = creatureResId,
+                        level = state.creatureStats.level,
+                        environmentResId = environmentResId,
+                        overrideCreature = { EduMonAvatar(showLevelLabel = false) })
 
-                  Row(
+                    Row(
                         Modifier.fillMaxWidth().height(IntrinsicSize.Min),
                         horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                           CreatureStatsCard(

--- a/app/src/main/java/com/android/sample/feature/homeScreen/HomeScreen.kt
+++ b/app/src/main/java/com/android/sample/feature/homeScreen/HomeScreen.kt
@@ -38,6 +38,7 @@ import com.android.sample.data.ToDo
 import com.android.sample.data.UserProfile
 import com.android.sample.screens.CreatureHouseCard
 import com.android.sample.screens.CreatureStatsCard
+import com.android.sample.ui.profile.EduMonAvatar
 import com.android.sample.ui.theme.AccentViolet
 import com.android.sample.ui.theme.MidDarkCard
 import kotlinx.coroutines.launch
@@ -180,11 +181,14 @@ fun EduMonHomeScreen(
                       .verticalScroll(rememberScrollState())
                       .padding(horizontal = 16.dp, vertical = 8.dp),
                   verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                    CreatureHouseCard(
-                        creatureResId = creatureResId,
-                        level = state.creatureStats.level,
-                        environmentResId = environmentResId)
-                    Row(
+                  CreatureHouseCard(
+                      creatureResId = creatureResId,
+                      level = state.creatureStats.level,
+                      environmentResId = environmentResId,
+                      overrideCreature = { EduMonAvatar(showLevelLabel = false) }
+                  )
+
+                  Row(
                         Modifier.fillMaxWidth().height(IntrinsicSize.Min),
                         horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                           CreatureStatsCard(

--- a/app/src/main/java/com/android/sample/screens/CreatureEnvironment.kt
+++ b/app/src/main/java/com/android/sample/screens/CreatureEnvironment.kt
@@ -9,33 +9,14 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.Bolt
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.outlined.LocalHospital
-import androidx.compose.material3.AssistChip
-import androidx.compose.material3.AssistChipDefaults
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ElevatedCard
-import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -52,120 +33,135 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.sample.data.CreatureStats
 
+
 @Composable
 fun CreatureHouseCard(
     creatureResId: Int,
     level: Int,
     environmentResId: Int,
     modifier: Modifier = Modifier,
+    overrideCreature: (@Composable () -> Unit)? = null,
 ) {
-  Surface(
-      modifier = modifier.fillMaxWidth(),
-      color = MaterialTheme.colorScheme.surface,
-      shape = RoundedCornerShape(24.dp),
-      tonalElevation = 1.dp,
-  ) {
-    Box(
-        modifier =
-            Modifier.fillMaxWidth().padding(16.dp).clip(RoundedCornerShape(20.dp)).height(220.dp)) {
-          Image(
-              painter = painterResource(environmentResId),
-              contentDescription = "Creature environment",
-              contentScale = ContentScale.Crop,
-              modifier = Modifier.fillMaxSize())
-          Box(
-              Modifier.align(Alignment.BottomCenter)
-                  .fillMaxWidth(0.7f)
-                  .height(6.dp)
-                  .clip(RoundedCornerShape(50))
-                  .background(MaterialTheme.colorScheme.onSurface.copy(alpha = .18f)))
-          CreatureSprite(
-              resId = creatureResId,
-              size = 120.dp,
-              modifier = Modifier.align(Alignment.BottomCenter).offset(y = (-28).dp))
-          AssistChip(
-              onClick = {},
-              label = { Text("Lv $level", color = MaterialTheme.colorScheme.primary) },
-              leadingIcon = {
-                Icon(Icons.Outlined.AutoAwesome, null, tint = MaterialTheme.colorScheme.primary)
-              },
-              colors =
-                  AssistChipDefaults.assistChipColors(
-                      containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                      labelColor = MaterialTheme.colorScheme.onSurface,
-                      leadingIconContentColor = MaterialTheme.colorScheme.primary),
-              modifier = Modifier.align(Alignment.TopStart).padding(10.dp))
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surface,
+        shape = RoundedCornerShape(24.dp),
+        tonalElevation = 1.dp,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+                .clip(RoundedCornerShape(20.dp))
+                .height(220.dp)
+        ) {
+            Image(
+                painter = painterResource(environmentResId),
+                contentDescription = "Creature environment",
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize()
+            )
+            Box(
+                Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth(0.7f)
+                    .height(6.dp)
+                    .clip(RoundedCornerShape(50))
+                    .background(MaterialTheme.colorScheme.onSurface.copy(alpha = .18f))
+            )
+            if (overrideCreature != null) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .offset(y = (-28).dp)
+                ) {
+                    overrideCreature()
+                }
+            } else {
+                CreatureSprite(
+                    resId = creatureResId,
+                    size = 120.dp,
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .offset(y = (-28).dp)
+                )
+            }
+            AssistChip(
+                onClick = {},
+                label = { Text("Lv $level", color = MaterialTheme.colorScheme.primary) },
+                leadingIcon = {
+                    Icon(Icons.Outlined.AutoAwesome, null, tint = MaterialTheme.colorScheme.primary)
+                },
+                colors = AssistChipDefaults.assistChipColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    labelColor = MaterialTheme.colorScheme.onSurface,
+                    leadingIconContentColor = MaterialTheme.colorScheme.primary
+                ),
+                modifier = Modifier.align(Alignment.TopStart).padding(10.dp)
+            )
         }
-  }
+    }
 }
 
 @Composable
 fun CreatureSprite(resId: Int, modifier: Modifier = Modifier, size: Dp = 120.dp) {
-  val inf = rememberInfiniteTransition(label = "float")
-  val offset by
-      inf.animateFloat(
-          initialValue = 0f,
-          targetValue = -10f,
-          animationSpec =
-              infiniteRepeatable(
-                  animation = tween(1800, easing = FastOutSlowInEasing),
-                  repeatMode = RepeatMode.Reverse),
-          label = "offset")
-  val glowAlpha by
-      inf.animateFloat(
-          initialValue = 0.25f,
-          targetValue = 0.5f,
-          animationSpec =
-              infiniteRepeatable(
-                  animation = tween(1400, easing = FastOutSlowInEasing),
-                  repeatMode = RepeatMode.Reverse),
-          label = "glow")
+    val inf = rememberInfiniteTransition(label = "float")
+    val offset by inf.animateFloat(
+        initialValue = 0f,
+        targetValue = -10f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(1800, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "offset"
+    )
+    val glowAlpha by inf.animateFloat(
+        initialValue = 0.25f,
+        targetValue = 0.5f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(1400, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "glow"
+    )
 
-  Box(modifier = modifier.size(size + 40.dp), contentAlignment = Alignment.Center) {
-    Canvas(modifier = Modifier.fillMaxSize()) {
-      drawCircle(
-          brush =
-              Brush.radialGradient(
-                  0.0f to Color(0xFFA26BF2).copy(alpha = glowAlpha), 1.0f to Color.Transparent),
-          radius = (size.value * 0.9f) * density,
-          center = center)
+    Box(modifier.size(size + 40.dp), contentAlignment = Alignment.Center) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            drawCircle(
+                brush = Brush.radialGradient(
+                    0f to Color(0xFFA26BF2).copy(alpha = glowAlpha),
+                    1f to Color.Transparent
+                ),
+                radius = (size.value * 0.9f) * density,
+                center = center
+            )
+        }
+        Image(
+            painter = painterResource(id = resId),
+            contentDescription = "Creature",
+            contentScale = ContentScale.Fit,
+            modifier = Modifier.size(size).offset(y = offset.dp)
+        )
     }
-    Image(
-        painter = painterResource(id = resId),
-        contentDescription = "Creature",
-        contentScale = ContentScale.Fit,
-        modifier = Modifier.size(size).offset(y = offset.dp))
-  }
 }
 
 @Composable
 fun CreatureStatsCard(stats: CreatureStats, modifier: Modifier = Modifier) {
-  ElevatedCard(
-      modifier,
-      colors =
-          CardDefaults.elevatedCardColors(
-              containerColor = MaterialTheme.colorScheme.surface,
-              contentColor = MaterialTheme.colorScheme.onSurface),
-      shape = RoundedCornerShape(20.dp)) {
+    ElevatedCard(
+        modifier,
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+            contentColor = MaterialTheme.colorScheme.onSurface
+        ),
+        shape = RoundedCornerShape(20.dp)
+    ) {
         Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
-          Text("Buddy Stats", fontWeight = FontWeight.SemiBold, fontSize = 16.sp)
-          StatRow(
-              "Happiness",
-              stats.happiness,
-              Icons.Outlined.FavoriteBorder,
-              barColor = MaterialTheme.colorScheme.primary)
-          StatRow(
-              "Health",
-              stats.health,
-              Icons.Outlined.LocalHospital,
-              barColor = MaterialTheme.colorScheme.secondary)
-          StatRow(
-              "Energy",
-              stats.energy,
-              Icons.Outlined.Bolt,
-              barColor = MaterialTheme.colorScheme.tertiary)
+            Text("Buddy Stats", fontWeight = FontWeight.SemiBold, fontSize = 16.sp)
+            StatRow("Happiness", stats.happiness, Icons.Outlined.FavoriteBorder, MaterialTheme.colorScheme.primary)
+            StatRow("Health", stats.health, Icons.Outlined.LocalHospital, MaterialTheme.colorScheme.secondary)
+            StatRow("Energy", stats.energy, Icons.Outlined.Bolt, MaterialTheme.colorScheme.tertiary)
         }
-      }
+    }
 }
 
 @Composable
@@ -175,18 +171,22 @@ private fun StatRow(
     icon: ImageVector,
     barColor: Color,
 ) {
-  Column {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-      Icon(icon, contentDescription = null, tint = barColor)
-      Spacer(Modifier.width(6.dp))
-      Text(title, modifier = Modifier.weight(1f))
-      Text("${value}%", color = MaterialTheme.colorScheme.onSurface)
+    Column {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(icon, contentDescription = null, tint = barColor)
+            Spacer(Modifier.width(6.dp))
+            Text(title, modifier = Modifier.weight(1f))
+            Text("$value%", color = MaterialTheme.colorScheme.onSurface)
+        }
+        Spacer(Modifier.height(6.dp))
+        LinearProgressIndicator(
+            progress = value / 100f,
+            trackColor = MaterialTheme.colorScheme.onSurface.copy(alpha = .20f),
+            color = barColor,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(8.dp)
+                .clip(RoundedCornerShape(8.dp))
+        )
     }
-    Spacer(Modifier.height(6.dp))
-    LinearProgressIndicator(
-        progress = value / 100f,
-        trackColor = MaterialTheme.colorScheme.onSurface.copy(alpha = .20f),
-        color = barColor,
-        modifier = Modifier.fillMaxWidth().height(8.dp).clip(RoundedCornerShape(8.dp)))
-  }
 }

--- a/app/src/main/java/com/android/sample/screens/CreatureEnvironment.kt
+++ b/app/src/main/java/com/android/sample/screens/CreatureEnvironment.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.sample.data.CreatureStats
 
-
 @Composable
 fun CreatureHouseCard(
     creatureResId: Int,
@@ -42,126 +41,115 @@ fun CreatureHouseCard(
     modifier: Modifier = Modifier,
     overrideCreature: (@Composable () -> Unit)? = null,
 ) {
-    Surface(
-        modifier = modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surface,
-        shape = RoundedCornerShape(24.dp),
-        tonalElevation = 1.dp,
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-                .clip(RoundedCornerShape(20.dp))
-                .height(220.dp)
-        ) {
-            Image(
-                painter = painterResource(environmentResId),
-                contentDescription = "Creature environment",
-                contentScale = ContentScale.Crop,
-                modifier = Modifier.fillMaxSize()
-            )
-            Box(
-                Modifier
-                    .align(Alignment.BottomCenter)
-                    .fillMaxWidth(0.7f)
-                    .height(6.dp)
-                    .clip(RoundedCornerShape(50))
-                    .background(MaterialTheme.colorScheme.onSurface.copy(alpha = .18f))
-            )
-            if (overrideCreature != null) {
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .offset(y = (-28).dp)
-                ) {
-                    overrideCreature()
-                }
-            } else {
-                CreatureSprite(
-                    resId = creatureResId,
-                    size = 120.dp,
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .offset(y = (-28).dp)
-                )
+  Surface(
+      modifier = modifier.fillMaxWidth(),
+      color = MaterialTheme.colorScheme.surface,
+      shape = RoundedCornerShape(24.dp),
+      tonalElevation = 1.dp,
+  ) {
+    Box(
+        modifier =
+            Modifier.fillMaxWidth().padding(16.dp).clip(RoundedCornerShape(20.dp)).height(220.dp)) {
+          Image(
+              painter = painterResource(environmentResId),
+              contentDescription = "Creature environment",
+              contentScale = ContentScale.Crop,
+              modifier = Modifier.fillMaxSize())
+          Box(
+              Modifier.align(Alignment.BottomCenter)
+                  .fillMaxWidth(0.7f)
+                  .height(6.dp)
+                  .clip(RoundedCornerShape(50))
+                  .background(MaterialTheme.colorScheme.onSurface.copy(alpha = .18f)))
+          if (overrideCreature != null) {
+            Box(modifier = Modifier.align(Alignment.BottomCenter).offset(y = (-28).dp)) {
+              overrideCreature()
             }
-            AssistChip(
-                onClick = {},
-                label = { Text("Lv $level", color = MaterialTheme.colorScheme.primary) },
-                leadingIcon = {
-                    Icon(Icons.Outlined.AutoAwesome, null, tint = MaterialTheme.colorScheme.primary)
-                },
-                colors = AssistChipDefaults.assistChipColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                    labelColor = MaterialTheme.colorScheme.onSurface,
-                    leadingIconContentColor = MaterialTheme.colorScheme.primary
-                ),
-                modifier = Modifier.align(Alignment.TopStart).padding(10.dp)
-            )
+          } else {
+            CreatureSprite(
+                resId = creatureResId,
+                size = 120.dp,
+                modifier = Modifier.align(Alignment.BottomCenter).offset(y = (-28).dp))
+          }
+          AssistChip(
+              onClick = {},
+              label = { Text("Lv $level", color = MaterialTheme.colorScheme.primary) },
+              leadingIcon = {
+                Icon(Icons.Outlined.AutoAwesome, null, tint = MaterialTheme.colorScheme.primary)
+              },
+              colors =
+                  AssistChipDefaults.assistChipColors(
+                      containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                      labelColor = MaterialTheme.colorScheme.onSurface,
+                      leadingIconContentColor = MaterialTheme.colorScheme.primary),
+              modifier = Modifier.align(Alignment.TopStart).padding(10.dp))
         }
-    }
+  }
 }
 
 @Composable
 fun CreatureSprite(resId: Int, modifier: Modifier = Modifier, size: Dp = 120.dp) {
-    val inf = rememberInfiniteTransition(label = "float")
-    val offset by inf.animateFloat(
-        initialValue = 0f,
-        targetValue = -10f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(1800, easing = FastOutSlowInEasing),
-            repeatMode = RepeatMode.Reverse
-        ),
-        label = "offset"
-    )
-    val glowAlpha by inf.animateFloat(
-        initialValue = 0.25f,
-        targetValue = 0.5f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(1400, easing = FastOutSlowInEasing),
-            repeatMode = RepeatMode.Reverse
-        ),
-        label = "glow"
-    )
+  val inf = rememberInfiniteTransition(label = "float")
+  val offset by
+      inf.animateFloat(
+          initialValue = 0f,
+          targetValue = -10f,
+          animationSpec =
+              infiniteRepeatable(
+                  animation = tween(1800, easing = FastOutSlowInEasing),
+                  repeatMode = RepeatMode.Reverse),
+          label = "offset")
+  val glowAlpha by
+      inf.animateFloat(
+          initialValue = 0.25f,
+          targetValue = 0.5f,
+          animationSpec =
+              infiniteRepeatable(
+                  animation = tween(1400, easing = FastOutSlowInEasing),
+                  repeatMode = RepeatMode.Reverse),
+          label = "glow")
 
-    Box(modifier.size(size + 40.dp), contentAlignment = Alignment.Center) {
-        Canvas(modifier = Modifier.fillMaxSize()) {
-            drawCircle(
-                brush = Brush.radialGradient(
-                    0f to Color(0xFFA26BF2).copy(alpha = glowAlpha),
-                    1f to Color.Transparent
-                ),
-                radius = (size.value * 0.9f) * density,
-                center = center
-            )
-        }
-        Image(
-            painter = painterResource(id = resId),
-            contentDescription = "Creature",
-            contentScale = ContentScale.Fit,
-            modifier = Modifier.size(size).offset(y = offset.dp)
-        )
+  Box(modifier.size(size + 40.dp), contentAlignment = Alignment.Center) {
+    Canvas(modifier = Modifier.fillMaxSize()) {
+      drawCircle(
+          brush =
+              Brush.radialGradient(
+                  0f to Color(0xFFA26BF2).copy(alpha = glowAlpha), 1f to Color.Transparent),
+          radius = (size.value * 0.9f) * density,
+          center = center)
     }
+    Image(
+        painter = painterResource(id = resId),
+        contentDescription = "Creature",
+        contentScale = ContentScale.Fit,
+        modifier = Modifier.size(size).offset(y = offset.dp))
+  }
 }
 
 @Composable
 fun CreatureStatsCard(stats: CreatureStats, modifier: Modifier = Modifier) {
-    ElevatedCard(
-        modifier,
-        colors = CardDefaults.elevatedCardColors(
-            containerColor = MaterialTheme.colorScheme.surface,
-            contentColor = MaterialTheme.colorScheme.onSurface
-        ),
-        shape = RoundedCornerShape(20.dp)
-    ) {
+  ElevatedCard(
+      modifier,
+      colors =
+          CardDefaults.elevatedCardColors(
+              containerColor = MaterialTheme.colorScheme.surface,
+              contentColor = MaterialTheme.colorScheme.onSurface),
+      shape = RoundedCornerShape(20.dp)) {
         Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
-            Text("Buddy Stats", fontWeight = FontWeight.SemiBold, fontSize = 16.sp)
-            StatRow("Happiness", stats.happiness, Icons.Outlined.FavoriteBorder, MaterialTheme.colorScheme.primary)
-            StatRow("Health", stats.health, Icons.Outlined.LocalHospital, MaterialTheme.colorScheme.secondary)
-            StatRow("Energy", stats.energy, Icons.Outlined.Bolt, MaterialTheme.colorScheme.tertiary)
+          Text("Buddy Stats", fontWeight = FontWeight.SemiBold, fontSize = 16.sp)
+          StatRow(
+              "Happiness",
+              stats.happiness,
+              Icons.Outlined.FavoriteBorder,
+              MaterialTheme.colorScheme.primary)
+          StatRow(
+              "Health",
+              stats.health,
+              Icons.Outlined.LocalHospital,
+              MaterialTheme.colorScheme.secondary)
+          StatRow("Energy", stats.energy, Icons.Outlined.Bolt, MaterialTheme.colorScheme.tertiary)
         }
-    }
+      }
 }
 
 @Composable
@@ -171,22 +159,18 @@ private fun StatRow(
     icon: ImageVector,
     barColor: Color,
 ) {
-    Column {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(icon, contentDescription = null, tint = barColor)
-            Spacer(Modifier.width(6.dp))
-            Text(title, modifier = Modifier.weight(1f))
-            Text("$value%", color = MaterialTheme.colorScheme.onSurface)
-        }
-        Spacer(Modifier.height(6.dp))
-        LinearProgressIndicator(
-            progress = value / 100f,
-            trackColor = MaterialTheme.colorScheme.onSurface.copy(alpha = .20f),
-            color = barColor,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(8.dp)
-                .clip(RoundedCornerShape(8.dp))
-        )
+  Column {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+      Icon(icon, contentDescription = null, tint = barColor)
+      Spacer(Modifier.width(6.dp))
+      Text(title, modifier = Modifier.weight(1f))
+      Text("$value%", color = MaterialTheme.colorScheme.onSurface)
     }
+    Spacer(Modifier.height(6.dp))
+    LinearProgressIndicator(
+        progress = value / 100f,
+        trackColor = MaterialTheme.colorScheme.onSurface.copy(alpha = .20f),
+        color = barColor,
+        modifier = Modifier.fillMaxWidth().height(8.dp).clip(RoundedCornerShape(8.dp)))
+  }
 }

--- a/app/src/main/java/com/android/sample/ui/games/FlappyEduMonScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/games/FlappyEduMonScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.sample.R
+import com.android.sample.ui.profile.EduMonAvatar
 import com.android.sample.ui.theme.*
 import kotlin.random.Random
 import kotlinx.coroutines.delay
@@ -162,18 +163,22 @@ fun FlappyEduMonScreen(
           }
         }
 
-        Image(
-            painter = painterResource(R.drawable.edumon),
-            contentDescription = "EduMon",
-            modifier =
-                Modifier.offset {
-                      IntOffset(
-                          (playerX - playerSizePx / 2f).toInt(),
-                          (playerY - playerSizePx / 2f).toInt())
-                    }
-                    .size(playerSizeDp))
+      Box(
+          modifier = Modifier
+              .offset {
+                  IntOffset(
+                      (playerX - playerSizePx / 2f).toInt(),
+                      (playerY - playerSizePx / 2f).toInt()
+                  )
+              }
+              .size(playerSizeDp)
+      ) {
+          EduMonAvatar(
+              showLevelLabel = false
+          )
+      }
 
-        Text(
+      Text(
             text = "Score: ${score.toInt()}",
             color = TextLight,
             fontSize = 22.sp,

--- a/app/src/main/java/com/android/sample/ui/games/FlappyEduMonScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/games/FlappyEduMonScreen.kt
@@ -1,7 +1,6 @@
 package com.android.sample.ui.games
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
@@ -16,12 +15,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.android.sample.R
 import com.android.sample.ui.profile.EduMonAvatar
 import com.android.sample.ui.theme.*
 import kotlin.random.Random
@@ -163,22 +160,18 @@ fun FlappyEduMonScreen(
           }
         }
 
-      Box(
-          modifier = Modifier
-              .offset {
-                  IntOffset(
-                      (playerX - playerSizePx / 2f).toInt(),
-                      (playerY - playerSizePx / 2f).toInt()
-                  )
-              }
-              .size(playerSizeDp)
-      ) {
-          EduMonAvatar(
-              showLevelLabel = false
-          )
-      }
+        Box(
+            modifier =
+                Modifier.offset {
+                      IntOffset(
+                          (playerX - playerSizePx / 2f).toInt(),
+                          (playerY - playerSizePx / 2f).toInt())
+                    }
+                    .size(playerSizeDp)) {
+              EduMonAvatar(showLevelLabel = false)
+            }
 
-      Text(
+        Text(
             text = "Score: ${score.toInt()}",
             color = TextLight,
             fontSize = 22.sp,

--- a/app/src/main/java/com/android/sample/ui/planner/PetHeader.kt
+++ b/app/src/main/java/com/android/sample/ui/planner/PetHeader.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.android.sample.R
 import com.android.sample.screens.CreatureHouseCard
+import com.android.sample.ui.profile.EduMonAvatar
 
 @Composable
 fun PetHeader(
@@ -13,12 +14,17 @@ fun PetHeader(
     environmentResId: Int = R.drawable.epfl_amphi_background,
     creatureResId: Int = R.drawable.edumon
 ) {
-  Box(modifier = modifier.fillMaxWidth()) {
-    // Exact same card as on the Home screen
-    CreatureHouseCard(
-        creatureResId = creatureResId,
-        level = level,
-        environmentResId = environmentResId,
-        modifier = Modifier.fillMaxWidth())
-  }
+    Box(modifier = modifier.fillMaxWidth()) {
+        CreatureHouseCard(
+            creatureResId = creatureResId,
+            level = level,
+            environmentResId = environmentResId,
+            overrideCreature = {
+                EduMonAvatar(
+                    showLevelLabel = false
+                )
+            },
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
 }

--- a/app/src/main/java/com/android/sample/ui/planner/PetHeader.kt
+++ b/app/src/main/java/com/android/sample/ui/planner/PetHeader.kt
@@ -14,17 +14,12 @@ fun PetHeader(
     environmentResId: Int = R.drawable.epfl_amphi_background,
     creatureResId: Int = R.drawable.edumon
 ) {
-    Box(modifier = modifier.fillMaxWidth()) {
-        CreatureHouseCard(
-            creatureResId = creatureResId,
-            level = level,
-            environmentResId = environmentResId,
-            overrideCreature = {
-                EduMonAvatar(
-                    showLevelLabel = false
-                )
-            },
-            modifier = Modifier.fillMaxWidth()
-        )
-    }
+  Box(modifier = modifier.fillMaxWidth()) {
+    CreatureHouseCard(
+        creatureResId = creatureResId,
+        level = level,
+        environmentResId = environmentResId,
+        overrideCreature = { EduMonAvatar(showLevelLabel = false) },
+        modifier = Modifier.fillMaxWidth())
+  }
 }

--- a/app/src/main/java/com/android/sample/ui/profile/EduMonAvatar.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/EduMonAvatar.kt
@@ -29,77 +29,68 @@ fun EduMonAvatar(
     showLevelLabel: Boolean = true,
     avatarSize: Dp = UiValues.AvatarSize,
 ) {
-    val user by viewModel.userProfile.collectAsState()
-    val accent by viewModel.accentEffective.collectAsState()
-    val accessories = user.accessories
+  val user by viewModel.userProfile.collectAsState()
+  val accent by viewModel.accentEffective.collectAsState()
+  val accessories = user.accessories
 
-    val equipped = remember(accessories) {
-        accessories.mapNotNull {
-            val p = it.split(":")
-            if (p.size == 2) p[0] to p[1] else null
-        }.toMap()
-    }
+  val equipped =
+      remember(accessories) {
+        accessories
+            .mapNotNull {
+              val p = it.split(":")
+              if (p.size == 2) p[0] to p[1] else null
+            }
+            .toMap()
+      }
 
-    Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
-    ) {
-
+  Column(
+      modifier = modifier,
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.Center) {
         Box(
-            modifier = Modifier
-                .size(avatarSize * UiValues.AvatarScale)
-                .clip(RoundedCornerShape(UiValues.AvatarCornerRadius)),
-            contentAlignment = Alignment.Center
-        ) {
+            modifier =
+                Modifier.size(avatarSize * UiValues.AvatarScale)
+                    .clip(RoundedCornerShape(UiValues.AvatarCornerRadius)),
+            contentAlignment = Alignment.Center) {
+              Box(
+                  modifier =
+                      Modifier.fillMaxSize()
+                          .background(
+                              Brush.radialGradient(
+                                  colors =
+                                      listOf(
+                                          accent.copy(alpha = UiValues.AuraAlpha),
+                                          Color.Transparent))))
 
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(
-                        Brush.radialGradient(
-                            colors = listOf(
-                                accent.copy(alpha = UiValues.AuraAlpha),
-                                Color.Transparent
-                            )
-                        )
-                    )
-            )
+              Image(
+                  painter = painterResource(id = R.drawable.edumon),
+                  contentDescription = stringResource(id = R.string.edumon_content_description),
+                  modifier = Modifier.size(avatarSize).zIndex(UiValues.ZBase))
 
-            Image(
-                painter = painterResource(id = R.drawable.edumon),
-                contentDescription = stringResource(id = R.string.edumon_content_description),
-                modifier = Modifier
-                    .size(avatarSize)
-                    .zIndex(UiValues.ZBase)
-            )
-
-            @Composable
-            fun draw(slot: AccessorySlot, z: Float) {
+              @Composable
+              fun draw(slot: AccessorySlot, z: Float) {
                 val id = equipped[slot.name.lowercase()] ?: return
                 val res = viewModel.accessoryResId(slot, id)
                 if (res != 0) {
-                    Image(
-                        painter = painterResource(res),
-                        contentDescription = null,
-                        modifier = Modifier.size(avatarSize).zIndex(z)
-                    )
+                  Image(
+                      painter = painterResource(res),
+                      contentDescription = null,
+                      modifier = Modifier.size(avatarSize).zIndex(z))
                 }
+              }
+
+              draw(AccessorySlot.BACK, UiValues.ZBack)
+              draw(AccessorySlot.TORSO, UiValues.ZTorso)
+              draw(AccessorySlot.HEAD, UiValues.ZHead)
             }
 
-            draw(AccessorySlot.BACK, UiValues.ZBack)
-            draw(AccessorySlot.TORSO, UiValues.ZTorso)
-            draw(AccessorySlot.HEAD, UiValues.ZHead)
-        }
-
         if (showLevelLabel) {
-            Spacer(Modifier.height(UiValues.AvatarLevelSpacing))
-            Text(
-                text = stringResource(R.string.level_label, user.level),
-                color = TextLight,
-                fontWeight = FontWeight.SemiBold,
-                fontSize = UiValues.LevelTextSize
-            )
+          Spacer(Modifier.height(UiValues.AvatarLevelSpacing))
+          Text(
+              text = stringResource(R.string.level_label, user.level),
+              color = TextLight,
+              fontWeight = FontWeight.SemiBold,
+              fontSize = UiValues.LevelTextSize)
         }
-    }
+      }
 }

--- a/app/src/main/java/com/android/sample/ui/profile/EduMonAvatar.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/EduMonAvatar.kt
@@ -1,0 +1,105 @@
+package com.android.sample.ui.profile
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.zIndex
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.android.sample.R
+import com.android.sample.data.AccessorySlot
+import com.android.sample.ui.theme.TextLight
+import com.android.sample.ui.theme.UiValues
+
+@Composable
+fun EduMonAvatar(
+    modifier: Modifier = Modifier,
+    viewModel: ProfileViewModel = viewModel(),
+    showLevelLabel: Boolean = true,
+    avatarSize: Dp = UiValues.AvatarSize,
+) {
+    val user by viewModel.userProfile.collectAsState()
+    val accent by viewModel.accentEffective.collectAsState()
+    val accessories = user.accessories
+
+    val equipped = remember(accessories) {
+        accessories.mapNotNull {
+            val p = it.split(":")
+            if (p.size == 2) p[0] to p[1] else null
+        }.toMap()
+    }
+
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+
+        Box(
+            modifier = Modifier
+                .size(avatarSize * UiValues.AvatarScale)
+                .clip(RoundedCornerShape(UiValues.AvatarCornerRadius)),
+            contentAlignment = Alignment.Center
+        ) {
+
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        Brush.radialGradient(
+                            colors = listOf(
+                                accent.copy(alpha = UiValues.AuraAlpha),
+                                Color.Transparent
+                            )
+                        )
+                    )
+            )
+
+            Image(
+                painter = painterResource(id = R.drawable.edumon),
+                contentDescription = stringResource(id = R.string.edumon_content_description),
+                modifier = Modifier
+                    .size(avatarSize)
+                    .zIndex(UiValues.ZBase)
+            )
+
+            @Composable
+            fun draw(slot: AccessorySlot, z: Float) {
+                val id = equipped[slot.name.lowercase()] ?: return
+                val res = viewModel.accessoryResId(slot, id)
+                if (res != 0) {
+                    Image(
+                        painter = painterResource(res),
+                        contentDescription = null,
+                        modifier = Modifier.size(avatarSize).zIndex(z)
+                    )
+                }
+            }
+
+            draw(AccessorySlot.BACK, UiValues.ZBack)
+            draw(AccessorySlot.TORSO, UiValues.ZTorso)
+            draw(AccessorySlot.HEAD, UiValues.ZHead)
+        }
+
+        if (showLevelLabel) {
+            Spacer(Modifier.height(UiValues.AvatarLevelSpacing))
+            Text(
+                text = stringResource(R.string.level_label, user.level),
+                color = TextLight,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = UiValues.LevelTextSize
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/android/sample/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/ProfileScreen.kt
@@ -135,11 +135,7 @@ fun ProfileScreen(
             verticalArrangement = Arrangement.spacedBy(SECTION_SPACING)) {
               item {
                 PetSection(
-                    level = user.level,
-                    accent = accent,
-                    accessories = user.accessories,
-                    viewModel = viewModel,
-                    variant = variant)
+                    viewModel = viewModel)
               }
               item {
                 GlowCard {
@@ -183,106 +179,46 @@ fun ProfileScreen(
 
 @Composable
 fun PetSection(
-    level: Int,
-    accent: Color,
-    accessories: List<String>,
-    variant: AccentVariant,
     viewModel: ProfileViewModel,
     modifier: Modifier = Modifier
 ) {
-  Box(
-      modifier =
-          modifier
-              .fillMaxWidth()
-              .background(Brush.verticalGradient(listOf(Color(0xFF0B0C24), Color(0xFF151737))))
-              .padding(vertical = 20.dp, horizontal = 16.dp)
-              .testTag(ProfileScreenTestTags.PET_SECTION)) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                Brush.verticalGradient(
+                    listOf(Color(0xFF0B0C24), Color(0xFF151737))
+                )
+            )
+            .padding(vertical = 20.dp, horizontal = 16.dp)
+            .testTag(ProfileScreenTestTags.PET_SECTION)
+    ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically) {
+            verticalAlignment = Alignment.CenterVertically
+        ) {
 
-              // === Left stat bars ===
-              Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 StatBar("❤️", 0.9f, StatBarHeart)
                 StatBar("💡", 0.85f, StatBarLightbulb)
                 StatBar("⚡", 0.7f, StatBarLightning)
-              }
-
-              // === Center avatar & accessories ===
-              Column(
-                  horizontalAlignment = Alignment.CenterHorizontally,
-                  verticalArrangement = Arrangement.Center) {
-                    Box(
-                        modifier = Modifier.size(130.dp).clip(RoundedCornerShape(100.dp)),
-                        contentAlignment = Alignment.Center) {
-                          // aura glow
-                          Box(
-                              Modifier.fillMaxSize()
-                                  .background(
-                                      Brush.radialGradient(
-                                          colors =
-                                              listOf(
-                                                  accent.copy(alpha = 0.55f), Color.Transparent))))
-
-                          // === SAFE ACCESSORY PARSING ===
-                          val equipped =
-                              remember(accessories) {
-                                accessories
-                                    .mapNotNull { raw ->
-                                      val parts = raw.split(":")
-                                      if (parts.size == 2) parts[0] to parts[1]
-                                      else null // ignore malformed entries like "none"
-                                    }
-                                    .toMap()
-                              }
-
-                          // Base avatar
-                          Image(
-                              painter = painterResource(id = R.drawable.edumon),
-                              contentDescription = "EduMon",
-                              modifier = Modifier.size(100.dp).zIndex(1f))
-
-                          // BACK ACCESSORIES (zIndex < avatar)
-                          equipped["back"]?.let { id ->
-                            val res = viewModel.accessoryResId(AccessorySlot.BACK, id)
-                            if (res != 0) {
-                              Image(
-                                  painter = painterResource(res),
-                                  contentDescription = null,
-                                  modifier = Modifier.size(100.dp).zIndex(0.5f))
-                            }
-                          }
-
-                          // TORSO ACCESSORIES
-                          equipped["torso"]?.let { id ->
-                            val res = viewModel.accessoryResId(AccessorySlot.TORSO, id)
-                            if (res != 0) {
-                              Image(
-                                  painter = painterResource(res),
-                                  contentDescription = null,
-                                  modifier = Modifier.size(100.dp).zIndex(2f))
-                            }
-                          }
-
-                          // HEAD ACCESSORIES
-                          equipped["head"]?.let { id ->
-                            val res = viewModel.accessoryResId(AccessorySlot.HEAD, id)
-                            if (res != 0) {
-                              Image(
-                                  painter = painterResource(res),
-                                  contentDescription = null,
-                                  modifier = Modifier.size(100.dp).zIndex(3f))
-                            }
-                          }
-                        }
-
-                    Spacer(Modifier.height(6.dp))
-                    Text("Level $level", color = TextLight, fontWeight = FontWeight.SemiBold)
-                  }
             }
-      }
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                EduMonAvatar(
+                    viewModel = viewModel,
+                    showLevelLabel = true,
+                    avatarSize = UiValues.AvatarSize
+                )
+            }
+        }
+    }
 }
+
 
 @Composable
 fun StatBar(icon: String, percent: Float, color: Color) {
@@ -579,7 +515,7 @@ fun SettingsCard(
         onToggle = {
           onToggleFocusMode()
           if (!user.focusModeEnabled) {
-            // Si on vient d’activer le focus mode → on lance l’écran
+
             onEnterFocusMode()
           }
         },

--- a/app/src/main/java/com/android/sample/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/ProfileScreen.kt
@@ -70,7 +70,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.zIndex
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.sample.R
 import com.android.sample.data.AccentVariant
@@ -133,10 +132,7 @@ fun ProfileScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             contentPadding = PaddingValues(vertical = SECTION_SPACING),
             verticalArrangement = Arrangement.spacedBy(SECTION_SPACING)) {
-              item {
-                PetSection(
-                    viewModel = viewModel)
-              }
+              item { PetSection(viewModel = viewModel) }
               item {
                 GlowCard {
                   Box(Modifier.testTag(ProfileScreenTestTags.PROFILE_CARD)) { ProfileCard(user) }
@@ -178,47 +174,35 @@ fun ProfileScreen(
 }
 
 @Composable
-fun PetSection(
-    viewModel: ProfileViewModel,
-    modifier: Modifier = Modifier
-) {
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .background(
-                Brush.verticalGradient(
-                    listOf(Color(0xFF0B0C24), Color(0xFF151737))
-                )
-            )
-            .padding(vertical = 20.dp, horizontal = 16.dp)
-            .testTag(ProfileScreenTestTags.PET_SECTION)
-    ) {
+fun PetSection(viewModel: ProfileViewModel, modifier: Modifier = Modifier) {
+  Box(
+      modifier =
+          modifier
+              .fillMaxWidth()
+              .background(Brush.verticalGradient(listOf(Color(0xFF0B0C24), Color(0xFF151737))))
+              .padding(vertical = 20.dp, horizontal = 16.dp)
+              .testTag(ProfileScreenTestTags.PET_SECTION)) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            verticalAlignment = Alignment.CenterVertically) {
+              Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 StatBar("❤️", 0.9f, StatBarHeart)
                 StatBar("💡", 0.85f, StatBarLightbulb)
                 StatBar("⚡", 0.7f, StatBarLightning)
-            }
+              }
 
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
-            ) {
-                EduMonAvatar(
-                    viewModel = viewModel,
-                    showLevelLabel = true,
-                    avatarSize = UiValues.AvatarSize
-                )
+              Column(
+                  horizontalAlignment = Alignment.CenterHorizontally,
+                  verticalArrangement = Arrangement.Center) {
+                    EduMonAvatar(
+                        viewModel = viewModel,
+                        showLevelLabel = true,
+                        avatarSize = UiValues.AvatarSize)
+                  }
             }
-        }
-    }
+      }
 }
-
 
 @Composable
 fun StatBar(icon: String, percent: Float, color: Color) {

--- a/app/src/main/java/com/android/sample/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/ProfileViewModel.kt
@@ -31,254 +31,214 @@ class ProfileViewModel(
     private val repository: ProfileRepository = ProfileRepositoryProvider.repository
 ) : ViewModel() {
 
-  companion object {
-    // XP required to advance by one level
-    const val POINTS_PER_LEVEL: Int = 300
-  }
-
-  // ----- Profil LOCAL uniquement -----
-  private val _userProfile = MutableStateFlow(repository.profile.value.copy())
-  val userProfile: StateFlow<UserProfile> = _userProfile
-
-  val accentPalette = listOf(PurplePrimary, AccentBlue, AccentMint, GlowGold, VioletSoft)
-  // reward engine instance
-  private val rewardEngine = LevelRewardEngine()
-
-  // one-shot events for UI (snackbar/dialog/etc.)
-  private val _rewardEvents = MutableSharedFlow<LevelUpRewardUiEvent>()
-  val rewardEvents: SharedFlow<LevelUpRewardUiEvent> = _rewardEvents
-
-  private fun fullCatalog(): List<AccessoryItem> =
-      listOf(
-          AccessoryItem("none", AccessorySlot.HEAD, "None"),
-          AccessoryItem("hat", AccessorySlot.HEAD, "Hat"),
-          AccessoryItem("glasses", AccessorySlot.HEAD, "Glasses"),
-          AccessoryItem("none", AccessorySlot.TORSO, "None"),
-          AccessoryItem("scarf", AccessorySlot.TORSO, "Scarf"),
-          AccessoryItem("cape", AccessorySlot.TORSO, "Cape"),
-          AccessoryItem("none", AccessorySlot.BACK, "None"),
-          AccessoryItem("wings", AccessorySlot.BACK, "Wings"),
-          AccessoryItem("aura", AccessorySlot.BACK, "Aura"))
-
-  val accessoryCatalog: List<AccessoryItem>
-    get() {
-      val owned = ownedIds()
-      return fullCatalog().filter { item -> item.id == "none" || owned.contains(item.id) }
+    companion object {
+        const val POINTS_PER_LEVEL: Int = 300
     }
 
-  private val accentVariant = MutableStateFlow(AccentVariant.Base)
-  val accentVariantFlow: StateFlow<AccentVariant> = accentVariant
+    private val _userProfile = MutableStateFlow(repository.profile.value.copy())
+    val userProfile: StateFlow<UserProfile> = _userProfile
 
-  val accentEffective: StateFlow<Color> =
-      combine(userProfile, accentVariantFlow) { user, variant ->
+    init {
+        viewModelScope.launch {
+            repository.profile.collect { newProfile ->
+                _userProfile.value = newProfile.copy()
+            }
+        }
+    }
+
+    val accentPalette = listOf(PurplePrimary, AccentBlue, AccentMint, GlowGold, VioletSoft)
+    private val rewardEngine = LevelRewardEngine()
+
+    private val _rewardEvents = MutableSharedFlow<LevelUpRewardUiEvent>()
+    val rewardEvents: SharedFlow<LevelUpRewardUiEvent> = _rewardEvents
+
+    private fun fullCatalog(): List<AccessoryItem> =
+        listOf(
+            AccessoryItem("none", AccessorySlot.HEAD, "None"),
+            AccessoryItem("hat", AccessorySlot.HEAD, "Hat"),
+            AccessoryItem("glasses", AccessorySlot.HEAD, "Glasses"),
+            AccessoryItem("none", AccessorySlot.TORSO, "None"),
+            AccessoryItem("scarf", AccessorySlot.TORSO, "Scarf"),
+            AccessoryItem("cape", AccessorySlot.TORSO, "Cape"),
+            AccessoryItem("none", AccessorySlot.BACK, "None"),
+            AccessoryItem("wings", AccessorySlot.BACK, "Wings"),
+            AccessoryItem("aura", AccessorySlot.BACK, "Aura"))
+
+    val accessoryCatalog: List<AccessoryItem>
+        get() {
+            val owned = ownedIds()
+            return fullCatalog().filter { item -> item.id == "none" || owned.contains(item.id) }
+        }
+
+    private val accentVariant = MutableStateFlow(AccentVariant.Base)
+    val accentVariantFlow: StateFlow<AccentVariant> = accentVariant
+
+    val accentEffective: StateFlow<Color> =
+        combine(userProfile, accentVariantFlow) { user, variant ->
             applyAccentVariant(Color(user.avatarAccent.toInt()), variant)
-          }
-          .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), Color(0xFF7C4DFF))
+        }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), Color(0xFF7C4DFF))
 
-  fun accessoryResId(slot: AccessorySlot, id: String): Int {
-    return when (slot) {
-      AccessorySlot.HEAD ->
-          when (id) {
-            "hat" -> R.drawable.cosmetic_hat
-            "glasses" -> R.drawable.cosmetic_glasses
+    fun accessoryResId(slot: AccessorySlot, id: String): Int {
+        return when (slot) {
+            AccessorySlot.HEAD ->
+                when (id) {
+                    "hat" -> R.drawable.cosmetic_hat
+                    "glasses" -> R.drawable.cosmetic_glasses
+                    else -> 0
+                }
+            AccessorySlot.TORSO ->
+                when (id) {
+                    "scarf" -> R.drawable.cosmetic_scarf
+                    "cape" -> R.drawable.cosmetic_cape
+                    else -> 0
+                }
+            AccessorySlot.BACK ->
+                when (id) {
+                    "wings" -> R.drawable.cosmetic_wings
+                    "aura" -> R.drawable.cosmetic_aura
+                    else -> 0
+                }
             else -> 0
-          }
-      AccessorySlot.TORSO ->
-          when (id) {
-            "scarf" -> R.drawable.cosmetic_scarf
-            "cape" -> R.drawable.cosmetic_cape
-            else -> 0
-          }
-      AccessorySlot.BACK ->
-          when (id) {
-            "wings" -> R.drawable.cosmetic_wings
-            "aura" -> R.drawable.cosmetic_aura
-            else -> 0
-          }
-      else -> 0
-    }
-  }
-
-  private fun ownedIds(): Set<String> {
-    return _userProfile.value.accessories
-        .filter { it.startsWith("owned:") }
-        .map { it.removePrefix("owned:") }
-        .toSet()
-  }
-
-  fun setAvatarAccent(color: Color) {
-    val argb = color.toArgb().toLong()
-    _userProfile.update { it.copy(avatarAccent = argb) }
-    pushProfile()
-  }
-
-  fun setAccentVariant(variant: AccentVariant) {
-    accentVariant.value = variant
-  }
-
-  fun toggleNotifications() = updateLocal {
-    it.copy(notificationsEnabled = !it.notificationsEnabled)
-  }
-
-  fun toggleLocation() = updateLocal { it.copy(locationEnabled = !it.locationEnabled) }
-
-  fun toggleFocusMode() = updateLocal { it.copy(focusModeEnabled = !it.focusModeEnabled) }
-
-  fun equip(slot: AccessorySlot, id: String) {
-
-    val owned = ownedIds()
-    if (id != "none" && !owned.contains(id)) return
-
-    val cur = _userProfile.value
-    val prefix = slot.name.lowercase() + ":"
-    val cleaned = cur.accessories.filterNot { it.startsWith(prefix) }
-
-    val updatedAccessories = if (id == "none") cleaned else cleaned + (prefix + id)
-
-    val updated = cur.copy(accessories = updatedAccessories)
-    _userProfile.value = updated
-    pushProfile(updated)
-  }
-
-  fun unequip(slot: AccessorySlot) {
-    val cur = _userProfile.value
-    val prefix = slot.name.lowercase() + ":"
-    val updated = cur.copy(accessories = cur.accessories.filterNot { it.startsWith(prefix) })
-    _userProfile.value = updated
-    pushProfile(updated)
-  }
-
-  fun equippedId(slot: AccessorySlot): String? {
-    val prefix = slot.name.lowercase() + ":"
-    val entry = _userProfile.value.accessories.firstOrNull { it.startsWith(prefix) } ?: return null
-    return entry.removePrefix(prefix)
-  }
-
-  private fun updateLocal(edit: (UserProfile) -> UserProfile) {
-    _userProfile.update(edit)
-    pushProfile()
-  }
-
-  private fun applyAccentVariant(base: Color, v: AccentVariant): Color =
-      when (v) {
-        AccentVariant.Base -> base
-        AccentVariant.Light ->
-            Color(
-                (base.red + (1f - base.red) * 0.25f),
-                (base.green + (1f - base.green) * 0.25f),
-                (base.blue + (1f - base.blue) * 0.25f),
-                base.alpha)
-        AccentVariant.Dark ->
-            Color(base.red * 0.75f, base.green * 0.75f, base.blue * 0.75f, base.alpha)
-        AccentVariant.Vibrant ->
-            Color(
-                (base.red * 1.1f).coerceIn(0f, 1f),
-                (base.green * 1.1f).coerceIn(0f, 1f),
-                (base.blue * 1.1f).coerceIn(0f, 1f),
-                base.alpha)
-      }
-
-  fun addCoins(amount: Int) {
-    if (amount <= 0) return
-    val current = _userProfile.value
-    val updated = current.copy(coins = current.coins + amount)
-    _userProfile.value = updated
-    pushProfile(updated)
-  }
-
-  /**
-   * Adds points to the user, recomputes the level based on total points, and routes the change
-   * through the reward engine.
-   *
-   * If the new level is higher than the old one:
-   * - LevelRewardEngine applies rewards
-   * - lastRewardedLevel is updated
-   * - UI receives a LevelUpRewardUiEvent
-   */
-  fun addPoints(amount: Int) {
-    if (amount <= 0) return
-
-    applyProfileWithPotentialRewards { current ->
-      val newPoints = (current.points + amount).coerceAtLeast(0)
-      val newLevel = computeLevelFromPoints(newPoints)
-      current.copy(points = newPoints, level = newLevel)
-    }
-  }
-
-  // --- Helpers ---
-  /**
-   * Pushes the current or provided profile to the repository. Centralizes the fire-and-forget
-   * update with error safety.
-   */
-  private fun pushProfile(updated: UserProfile = _userProfile.value) {
-    viewModelScope.launch { runCatching { repository.updateProfile(updated) } }
-  }
-
-  /**
-   * Applies a change to the profile (via [edit]) and, if that change includes a level increase,
-   * routes the old/new profiles through the reward engine.
-   * - If level didn't increase → just update and push as usual.
-   * - If level increased → apply rewards, update profile, push, and emit UI event.
-   */
-  private fun applyProfileWithPotentialRewards(edit: (UserProfile) -> UserProfile) {
-    val oldProfile = _userProfile.value
-    val candidate = edit(oldProfile)
-
-    // No level up → regular path
-    if (candidate.level <= oldProfile.level) {
-      _userProfile.value = candidate
-      pushProfile(candidate)
-      return
+        }
     }
 
-    // Level increased → let the reward engine do its job
-    val result = rewardEngine.applyLevelUpRewards(oldProfile, candidate)
-    val updated = result.updatedProfile
-
-    _userProfile.value = updated
-    pushProfile(updated)
-
-    // Emit UI event only if something was actually rewarded
-    if (!result.summary.isEmpty) {
-      viewModelScope.launch {
-        _rewardEvents.emit(
-            LevelUpRewardUiEvent.RewardsGranted(newLevel = updated.level, summary = result.summary))
-      }
+    private fun ownedIds(): Set<String> {
+        return _userProfile.value.accessories
+            .filter { it.startsWith("owned:") }
+            .map { it.removePrefix("owned:") }
+            .toSet()
     }
-  }
 
-  /**
-   * Computes the level for a given amount of points.
-   *
-   * Simple rule:
-   * - Every 300 points = +1 level
-   * - Minimum level is 1
-   */
-  private fun computeLevelFromPoints(points: Int): Int {
-    if (points <= 0) return 1
-    return 1 + (points / POINTS_PER_LEVEL)
-  }
-  /**
-   * DEBUG / TEST-ONLY helper.
-   *
-   * This function exists purely to simplify unit testing of the reward system. Not used in
-   * production UI. It's kept to make reward-related tests shorter, more deterministic, and easier
-   * to maintain (if we later decide to change the level up calculation)
-   */
-  fun debugLevelUpForTests() {
-    applyProfileWithPotentialRewards { current -> current.copy(level = current.level + 1) }
-  }
-  /**
-   * DEBUG / TEST-ONLY helper.
-   *
-   * This function exists purely to simplify unit testing of the reward system. Not used in
-   * production UI. It's kept to make reward-related tests shorter, more deterministic, and easier
-   * to maintain (if we later decide to change the level up calculation)
-   */
-  fun debugNoLevelChangeForTests() {
-    applyProfileWithPotentialRewards { current ->
-      // Change points, keep level the same
-      current.copy(points = current.points + 10)
+    fun setAvatarAccent(color: Color) {
+        val argb = color.toArgb().toLong()
+        _userProfile.update { it.copy(avatarAccent = argb) }
+        pushProfile()
     }
-  }
+
+    fun setAccentVariant(variant: AccentVariant) {
+        accentVariant.value = variant
+    }
+
+    fun toggleNotifications() = updateLocal {
+        it.copy(notificationsEnabled = !it.notificationsEnabled)
+    }
+
+    fun toggleLocation() = updateLocal { it.copy(locationEnabled = !it.locationEnabled) }
+
+    fun toggleFocusMode() = updateLocal { it.copy(focusModeEnabled = !it.focusModeEnabled) }
+
+    fun equip(slot: AccessorySlot, id: String) {
+        val owned = ownedIds()
+        if (id != "none" && !owned.contains(id)) return
+
+        val cur = _userProfile.value
+        val prefix = slot.name.lowercase() + ":"
+        val cleaned = cur.accessories.filterNot { it.startsWith(prefix) }
+        val updatedAccessories = if (id == "none") cleaned else cleaned + (prefix + id)
+        val updated = cur.copy(accessories = updatedAccessories)
+
+        _userProfile.value = updated
+        pushProfile(updated)
+    }
+
+    fun unequip(slot: AccessorySlot) {
+        val cur = _userProfile.value
+        val prefix = slot.name.lowercase() + ":"
+        val updated = cur.copy(accessories = cur.accessories.filterNot { it.startsWith(prefix) })
+        _userProfile.value = updated
+        pushProfile(updated)
+    }
+
+    fun equippedId(slot: AccessorySlot): String? {
+        val prefix = slot.name.lowercase() + ":"
+        val entry = _userProfile.value.accessories.firstOrNull { it.startsWith(prefix) } ?: return null
+        return entry.removePrefix(prefix)
+    }
+
+    private fun updateLocal(edit: (UserProfile) -> UserProfile) {
+        _userProfile.update(edit)
+        pushProfile()
+    }
+
+    private fun applyAccentVariant(base: Color, v: AccentVariant): Color =
+        when (v) {
+            AccentVariant.Base -> base
+            AccentVariant.Light ->
+                Color(
+                    (base.red + (1f - base.red) * 0.25f),
+                    (base.green + (1f - base.green) * 0.25f),
+                    (base.blue + (1f - base.blue) * 0.25f),
+                    base.alpha)
+            AccentVariant.Dark ->
+                Color(base.red * 0.75f, base.green * 0.75f, base.blue * 0.75f, base.alpha)
+            AccentVariant.Vibrant ->
+                Color(
+                    (base.red * 1.1f).coerceIn(0f, 1f),
+                    (base.green * 1.1f).coerceIn(0f, 1f),
+                    (base.blue * 1.1f).coerceIn(0f, 1f),
+                    base.alpha)
+        }
+
+    fun addCoins(amount: Int) {
+        if (amount <= 0) return
+        val current = _userProfile.value
+        val updated = current.copy(coins = current.coins + amount)
+        _userProfile.value = updated
+        pushProfile(updated)
+    }
+
+    fun addPoints(amount: Int) {
+        if (amount <= 0) return
+
+        applyProfileWithPotentialRewards { current ->
+            val newPoints = (current.points + amount).coerceAtLeast(0)
+            val newLevel = computeLevelFromPoints(newPoints)
+            current.copy(points = newPoints, level = newLevel)
+        }
+    }
+
+    private fun pushProfile(updated: UserProfile = _userProfile.value) {
+        viewModelScope.launch { runCatching { repository.updateProfile(updated) } }
+    }
+
+    private fun applyProfileWithPotentialRewards(edit: (UserProfile) -> UserProfile) {
+        val oldProfile = _userProfile.value
+        val candidate = edit(oldProfile)
+
+        if (candidate.level <= oldProfile.level) {
+            _userProfile.value = candidate
+            pushProfile(candidate)
+            return
+        }
+
+        val result = rewardEngine.applyLevelUpRewards(oldProfile, candidate)
+        val updated = result.updatedProfile
+
+        _userProfile.value = updated
+        pushProfile(updated)
+
+        if (!result.summary.isEmpty) {
+            viewModelScope.launch {
+                _rewardEvents.emit(
+                    LevelUpRewardUiEvent.RewardsGranted(
+                        newLevel = updated.level, summary = result.summary))
+            }
+        }
+    }
+
+    private fun computeLevelFromPoints(points: Int): Int {
+        if (points <= 0) return 1
+        return 1 + (points / POINTS_PER_LEVEL)
+    }
+
+    fun debugLevelUpForTests() {
+        applyProfileWithPotentialRewards { current -> current.copy(level = current.level + 1) }
+    }
+
+    fun debugNoLevelChangeForTests() {
+        applyProfileWithPotentialRewards { current ->
+            current.copy(points = current.points + 10)
+        }
+    }
 }

--- a/app/src/main/java/com/android/sample/ui/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/schedule/ScheduleScreen.kt
@@ -139,7 +139,6 @@ fun ScheduleScreen() {
                     .padding(horizontal = 16.dp, vertical = 8.dp)
                     .testTag(ScheduleScreenTestTags.ROOT),
             horizontalAlignment = Alignment.CenterHorizontally) {
-
               PetHeader(level = 5)
 
               Spacer(Modifier.height(8.dp))

--- a/app/src/main/java/com/android/sample/ui/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/schedule/ScheduleScreen.kt
@@ -37,7 +37,7 @@ import com.android.sample.ui.theme.PurplePrimary
 import java.time.LocalDate
 import java.time.YearMonth
 
-/** This class was implemented with the help of ai (chatgbt) */
+/** This class was implemented with the help of ai (ChatGPT) */
 object ScheduleScreenTestTags {
   const val ROOT = "schedule_root"
   const val TAB_ROW = "schedule_tab_row"
@@ -139,7 +139,7 @@ fun ScheduleScreen() {
                     .padding(horizontal = 16.dp, vertical = 8.dp)
                     .testTag(ScheduleScreenTestTags.ROOT),
             horizontalAlignment = Alignment.CenterHorizontally) {
-              // Header now matches Home (use the updated PetHeader you implemented)
+
               PetHeader(level = 5)
 
               Spacer(Modifier.height(8.dp))

--- a/app/src/main/java/com/android/sample/ui/theme/UiValues.kt
+++ b/app/src/main/java/com/android/sample/ui/theme/UiValues.kt
@@ -4,17 +4,17 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 object UiValues {
-    val AvatarSize = 100.dp
-    val AvatarCornerRadius = 100.dp
-    val AvatarLevelSpacing = 6.dp
-    const val AvatarScale = 1.3f
+  val AvatarSize = 100.dp
+  val AvatarCornerRadius = 100.dp
+  val AvatarLevelSpacing = 6.dp
+  const val AvatarScale = 1.3f
 
-    const val ZBack = 0.5f
-    const val ZBase = 1f
-    const val ZTorso = 2f
-    const val ZHead = 3f
+  const val ZBack = 0.5f
+  const val ZBase = 1f
+  const val ZTorso = 2f
+  const val ZHead = 3f
 
-    const val AuraAlpha = 0.55f
+  const val AuraAlpha = 0.55f
 
-    val LevelTextSize = 14.sp
+  val LevelTextSize = 14.sp
 }

--- a/app/src/main/java/com/android/sample/ui/theme/UiValues.kt
+++ b/app/src/main/java/com/android/sample/ui/theme/UiValues.kt
@@ -1,0 +1,20 @@
+package com.android.sample.ui.theme
+
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+object UiValues {
+    val AvatarSize = 100.dp
+    val AvatarCornerRadius = 100.dp
+    val AvatarLevelSpacing = 6.dp
+    const val AvatarScale = 1.3f
+
+    const val ZBack = 0.5f
+    const val ZBase = 1f
+    const val ZTorso = 2f
+    const val ZHead = 3f
+
+    const val AuraAlpha = 0.55f
+
+    val LevelTextSize = 14.sp
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -307,6 +307,10 @@
     <!-- StudyTogether UI -->
     <string name="study_together_no_friends_yet">No friends yet</string>
 
+    <string name="edumon_content_description">EduMon character</string>
+    <string name="level_label">Level %1$d</string>
+
+
 
 
 


### PR DESCRIPTION
## Summary
This PR ensures consistent rendering of the EduMon avatar across the entire application.  
Previously, only the ProfileScreen reflected the user's customized EduMon (accessories, aura, accent color), while other screens still displayed a static sprite.  
This inconsistency weakened the customization feature and created a fragmented user experience.  
This PR unifies the EduMon rendering logic across all major screens.

## What’s in this PR
- Replaced all static `R.drawable.edumon` usages with the dynamic `EduMonAvatar` composable.
- Updated `CreatureHouseCard` to support a `overrideCreature` composable for flexible avatar injection.
- Updated ScheduleScreen to display the real customized EduMon via `PetHeader` override.
- Updated FlappyEduMonScreen to use `EduMonAvatar` as the player sprite.
- Ensured ProfileViewModel automatically synchronizes `_userProfile` with Firestore updates.
- No API/Firestore schema changes.

## Implementation Notes
- Chosen approach: each screen uses its own instance of `ProfileViewModel` but stays fully synchronized through `repository.profile.collect { ... }`.
- This avoids altering navigation graphs or introducing shared ViewModel complexity.
- EduMonAvatar handles its own ViewModel by default unless explicitly injected.
- Performance remains unchanged: recompositions only occur on actual user profile updates.
- No additional Firestore reads beyond the existing reactive stream.

## Testing
**Unit Tests**
- Verified ProfileViewModel syncs correctly with repository updates.
- Validated accessory and accent computation logic.

**UI/Instrumented Tests**
- Home screen: EduMon renders with correct accessories.
- Schedule screen: Header displays updated EduMon.
- Flappy game: Player sprite updates based on latest customization.
- Navigation between screens retains avatar consistency.

## Screenshots / Demos
<img width="670" height="1528" alt="image" src="https://github.com/user-attachments/assets/5e4fcf2c-720c-42bd-87d0-ff6c164faa92" />
<img width="628" height="1348" alt="image" src="https://github.com/user-attachments/assets/15aa4e16-bb5c-49bf-ac7f-03564daae73e" />
<img width="670" height="1332" alt="image" src="https://github.com/user-attachments/assets/f2281354-e903-401c-b181-10b557b1c566" />


## Checklist
- [x] EduMon rendered consistently on Home
- [x] EduMon rendered consistently on Schedule
- [x] EduMon rendered consistently in Flappy game
- [x] Avatar updates propagate across screens instantly
- [x] No regressions in layout or background visuals
- [x] All static sprite usages removed
- [x] Required tests added/updated

## Notes
- The implementation preserves all existing layouts and backgrounds.
- No gameplay logic or layout structures were altered.
- Additional screens can easily adopt the same pattern if needed.

## Issue Reference
Closes #178
