### PR TITLE
feat(obj_consistency) : made objective consistent with firebase and a…

### DIFF
--- a/app/src/main/java/com/android/sample/feature/weeks/model/DefaultObjectives.kt
+++ b/app/src/main/java/com/android/sample/feature/weeks/model/DefaultObjectives.kt
@@ -9,12 +9,20 @@ import java.time.DayOfWeek
  * empty.
  */
 object DefaultObjectives {
+
+  // Course constants to avoid duplication
+  private const val COURSE_CS_200 = "CS-200"
+  private const val COURSE_CS_201 = "CS-201"
+  private const val COURSE_COM_100 = "COM-100"
+  private const val COURSE_SHS_150 = "SHS-150"
+  private const val COURSE_CS_100 = "CS-100"
+
   fun get(): List<Objective> =
       listOf(
           // Week 1 - Monday
           Objective(
               title = "Complete Quiz 1",
-              course = "CS-200",
+              course = COURSE_CS_200,
               estimateMinutes = 30,
               completed = false,
               day = DayOfWeek.MONDAY,
@@ -22,7 +30,7 @@ object DefaultObjectives {
           ),
           Objective(
               title = "Read Chapter 1",
-              course = "CS-200",
+              course = COURSE_CS_200,
               estimateMinutes = 45,
               completed = false,
               day = DayOfWeek.MONDAY,
@@ -32,7 +40,7 @@ object DefaultObjectives {
           // Week 1 - Tuesday
           Objective(
               title = "Solve Exercise Set 1",
-              course = "CS-201",
+              course = COURSE_CS_201,
               estimateMinutes = 60,
               completed = false,
               day = DayOfWeek.TUESDAY,
@@ -40,7 +48,7 @@ object DefaultObjectives {
           ),
           Objective(
               title = "Review Lecture Notes",
-              course = "CS-201",
+              course = COURSE_CS_201,
               estimateMinutes = 30,
               completed = false,
               day = DayOfWeek.TUESDAY,
@@ -50,7 +58,7 @@ object DefaultObjectives {
           // Week 1 - Wednesday
           Objective(
               title = "Lab Assignment 1",
-              course = "COM-100",
+              course = COURSE_COM_100,
               estimateMinutes = 90,
               completed = false,
               day = DayOfWeek.WEDNESDAY,
@@ -58,7 +66,7 @@ object DefaultObjectives {
           ),
           Objective(
               title = "Quiz 2",
-              course = "COM-100",
+              course = COURSE_COM_100,
               estimateMinutes = 20,
               completed = false,
               day = DayOfWeek.WEDNESDAY,
@@ -68,7 +76,7 @@ object DefaultObjectives {
           // Week 1 - Thursday
           Objective(
               title = "Reading Assignment",
-              course = "SHS-150",
+              course = COURSE_SHS_150,
               estimateMinutes = 45,
               completed = false,
               day = DayOfWeek.THURSDAY,
@@ -76,7 +84,7 @@ object DefaultObjectives {
           ),
           Objective(
               title = "Essay Outline",
-              course = "SHS-150",
+              course = COURSE_SHS_150,
               estimateMinutes = 30,
               completed = false,
               day = DayOfWeek.THURSDAY,
@@ -84,7 +92,7 @@ object DefaultObjectives {
           ),
           Objective(
               title = "Discussion Forum Post",
-              course = "SHS-150",
+              course = COURSE_SHS_150,
               estimateMinutes = 15,
               completed = false,
               day = DayOfWeek.THURSDAY,
@@ -94,7 +102,7 @@ object DefaultObjectives {
           // Week 1 - Friday
           Objective(
               title = "Problem Set 2",
-              course = "CS-100",
+              course = COURSE_CS_100,
               estimateMinutes = 75,
               completed = false,
               day = DayOfWeek.FRIDAY,
@@ -102,7 +110,7 @@ object DefaultObjectives {
           ),
           Objective(
               title = "Weekly Quiz",
-              course = "CS-100",
+              course = COURSE_CS_100,
               estimateMinutes = 25,
               completed = false,
               day = DayOfWeek.FRIDAY,
@@ -112,7 +120,7 @@ object DefaultObjectives {
           // Weekend
           Objective(
               title = "Review Week 1 Material",
-              course = "CS-200",
+              course = COURSE_CS_200,
               estimateMinutes = 60,
               completed = false,
               day = DayOfWeek.SATURDAY,
@@ -120,7 +128,7 @@ object DefaultObjectives {
           ),
           Objective(
               title = "Prepare for Midterm",
-              course = "COM-100",
+              course = COURSE_COM_100,
               estimateMinutes = 90,
               completed = false,
               day = DayOfWeek.SUNDAY,

--- a/app/src/main/java/com/android/sample/feature/weeks/model/DefaultObjectives.kt
+++ b/app/src/main/java/com/android/sample/feature/weeks/model/DefaultObjectives.kt
@@ -1,0 +1,130 @@
+// filepath:
+// c:\Users\Khalil\EduMon\app\src\main\java\com\android\sample\feature\weeks\model\DefaultObjectives.kt
+package com.android.sample.feature.weeks.model
+
+import java.time.DayOfWeek
+
+/**
+ * Provides default objectives for new users. These are seeded when a user's objectives list is
+ * empty.
+ */
+object DefaultObjectives {
+  fun get(): List<Objective> =
+      listOf(
+          // Week 1 - Monday
+          Objective(
+              title = "Complete Quiz 1",
+              course = "CS-200",
+              estimateMinutes = 30,
+              completed = false,
+              day = DayOfWeek.MONDAY,
+              type = ObjectiveType.QUIZ,
+          ),
+          Objective(
+              title = "Read Chapter 1",
+              course = "CS-200",
+              estimateMinutes = 45,
+              completed = false,
+              day = DayOfWeek.MONDAY,
+              type = ObjectiveType.COURSE_OR_EXERCISES,
+          ),
+
+          // Week 1 - Tuesday
+          Objective(
+              title = "Solve Exercise Set 1",
+              course = "CS-201",
+              estimateMinutes = 60,
+              completed = false,
+              day = DayOfWeek.TUESDAY,
+              type = ObjectiveType.COURSE_OR_EXERCISES,
+          ),
+          Objective(
+              title = "Review Lecture Notes",
+              course = "CS-201",
+              estimateMinutes = 30,
+              completed = false,
+              day = DayOfWeek.TUESDAY,
+              type = ObjectiveType.RESUME,
+          ),
+
+          // Week 1 - Wednesday
+          Objective(
+              title = "Lab Assignment 1",
+              course = "COM-100",
+              estimateMinutes = 90,
+              completed = false,
+              day = DayOfWeek.WEDNESDAY,
+              type = ObjectiveType.COURSE_OR_EXERCISES,
+          ),
+          Objective(
+              title = "Quiz 2",
+              course = "COM-100",
+              estimateMinutes = 20,
+              completed = false,
+              day = DayOfWeek.WEDNESDAY,
+              type = ObjectiveType.QUIZ,
+          ),
+
+          // Week 1 - Thursday
+          Objective(
+              title = "Reading Assignment",
+              course = "SHS-150",
+              estimateMinutes = 45,
+              completed = false,
+              day = DayOfWeek.THURSDAY,
+              type = ObjectiveType.COURSE_OR_EXERCISES,
+          ),
+          Objective(
+              title = "Essay Outline",
+              course = "SHS-150",
+              estimateMinutes = 30,
+              completed = false,
+              day = DayOfWeek.THURSDAY,
+              type = ObjectiveType.RESUME,
+          ),
+          Objective(
+              title = "Discussion Forum Post",
+              course = "SHS-150",
+              estimateMinutes = 15,
+              completed = false,
+              day = DayOfWeek.THURSDAY,
+              type = ObjectiveType.COURSE_OR_EXERCISES,
+          ),
+
+          // Week 1 - Friday
+          Objective(
+              title = "Problem Set 2",
+              course = "CS-100",
+              estimateMinutes = 75,
+              completed = false,
+              day = DayOfWeek.FRIDAY,
+              type = ObjectiveType.COURSE_OR_EXERCISES,
+          ),
+          Objective(
+              title = "Weekly Quiz",
+              course = "CS-100",
+              estimateMinutes = 25,
+              completed = false,
+              day = DayOfWeek.FRIDAY,
+              type = ObjectiveType.QUIZ,
+          ),
+
+          // Weekend
+          Objective(
+              title = "Review Week 1 Material",
+              course = "CS-200",
+              estimateMinutes = 60,
+              completed = false,
+              day = DayOfWeek.SATURDAY,
+              type = ObjectiveType.RESUME,
+          ),
+          Objective(
+              title = "Prepare for Midterm",
+              course = "COM-100",
+              estimateMinutes = 90,
+              completed = false,
+              day = DayOfWeek.SUNDAY,
+              type = ObjectiveType.RESUME,
+          ),
+      )
+}

--- a/app/src/main/java/com/android/sample/feature/weeks/ui/DailyObjectivesSection.kt
+++ b/app/src/main/java/com/android/sample/feature/weeks/ui/DailyObjectivesSection.kt
@@ -113,7 +113,7 @@ fun DailyObjectivesSection(
             enter = fadeIn() + expandVertically(),
             exit = fadeOut() + shrinkVertically()) {
               Column(modifier = Modifier.padding(top = 16.dp)) {
-                remaining.forEachIndexed { idx, obj ->
+                remaining.forEachIndexed { _, obj ->
                   HorizontalDivider(
                       modifier = Modifier.padding(vertical = 14.dp),
                       color = cs.onSurface.copy(alpha = 0.08f))

--- a/app/src/main/java/com/android/sample/feature/weeks/ui/WeekProgDailyObjTags.kt
+++ b/app/src/main/java/com/android/sample/feature/weeks/ui/WeekProgDailyObjTags.kt
@@ -26,6 +26,7 @@ object WeekProgDailyObjTags {
 
   // Objectives section
   const val OBJECTIVES_SECTION = "OBJECTIVES_SECTION"
+  const val OBJECTIVES_HEADER = "OBJECTIVES_HEADER"
   const val OBJECTIVES_TOGGLE = "OBJECTIVES_TOGGLE"
   const val OBJECTIVES_EMPTY = "OBJECTIVES_EMPTY"
   const val OBJECTIVES_SHOW_ALL_BUTTON = "OBJECTIVES_SHOW_ALL_BUTTON"
@@ -33,6 +34,7 @@ object WeekProgDailyObjTags {
 
   // Objective rows prefixes (index appended)
   const val OBJECTIVE_ROW_PREFIX = "OBJECTIVE_ROW_"
+  const val OBJECTIVE_TITLE_PREFIX = "OBJECTIVE_TITLE_"
   const val OBJECTIVE_START_BUTTON_PREFIX = "OBJECTIVE_START_BUTTON_"
   const val OBJECTIVE_REASON_PREFIX = "OBJECTIVE_REASON_"
 


### PR DESCRIPTION
# Daily Objectives: Firestore Integration & Day-Based Filtering

## Summary

**Problem**: The app previously used an in-memory fake repository for objectives, meaning data was lost on restart and not synchronized across devices. Additionally, objectives weren't filtered by day of the week in the schedule screen, making it difficult for users to focus on daily tasks.

**Solution**: This PR implements a production-ready Firestore backend for objectives with full CRUD operations, automatic day-of-week filtering in the schedule UI, and real-time completion status syncing. New users automatically receive 13 default objectives distributed across the week.

## What's in this PR

### Functional Changes

- **Firestore Objectives Repository**: Complete migration from `FakeObjectivesRepository` to `FirestoreObjectivesRepository` with cloud persistence
- **Day-Based Filtering**: Schedule screen now filters and displays only objectives assigned to the selected day (Monday, Tuesday, etc.)
- **Completion Status Sync**: Marking objectives as complete/incomplete immediately updates Firebase
- **Start Button Integration**: Tapping "Start" marks the objective complete in Firestore and navigates to the appropriate screen (Quiz/Course/Resume)
- **Default Objectives Seeding**: New users automatically get 13 pre-configured objectives across all days of the week
- **Offline Fallback**: When user is not signed in, app uses default objectives (no Firestore access required)
- **String Constant Refactoring**: Extracted duplicated course codes into constants to fix SonarCloud issues

### Firestore Schema Changes

**New Collection Structure**:
```
/users/{userId}/objectives/{objectiveId}
  ├─ title: String               // "Complete Quiz 1"
  ├─ course: String              // "CS-200"
  ├─ estimateMinutes: Long       // 30
  ├─ completed: Boolean          // false
  ├─ day: String                 // "MONDAY" (DayOfWeek enum name)
  ├─ type: String                // "QUIZ" | "COURSE_OR_EXERCISES" | "RESUME"
  ├─ order: Long                 // 0, 1, 2... (for custom ordering)
  ├─ createdAt: Timestamp        // Server timestamp
  └─ updatedAt: Timestamp        // Server timestamp
```

**Required Index** (auto-created):
- Collection: `users/{userId}/objectives`
- Field: `order` (ASCENDING)

**Data Isolation**: Each user has their own subcollection under `/users/{uid}/objectives`

## Implementation Notes

### Key Decisions & Trade-offs

1. **User-Scoped Collections**: Objectives stored in subcollections (`/users/{uid}/objectives`) rather than a single global collection
   - ✅ Better security rules (user can only access their own data)
   - ✅ Simpler queries (no need to filter by userId)
   - ⚠️ Slightly more complex Firestore rules structure

2. **Explicit Order Field**: Added `order: Long` field instead of relying on document creation time
   - ✅ Allows custom user reordering (drag-and-drop support)
   - ✅ Predictable, stable ordering
   - ⚠️ Requires batch updates when reordering multiple items

3. **Day Stored as String**: `DayOfWeek` enum serialized as string (`"MONDAY"`, `"TUESDAY"`, etc.)
   - ✅ Human-readable in Firestore console
   - ✅ Easy debugging
   - ⚠️ Requires enum conversion on read/write

4. **No Real-Time Listeners**: Repository uses explicit `refresh()` calls instead of Firestore listeners
   - ✅ Simpler state management
   - ✅ Lower battery/network usage
   - ⚠️ Manual refresh needed for multi-device sync (can add listeners later if needed)

5. **Default Objectives Fallback**: When unsigned, returns `DefaultObjectives.get()` instead of throwing error
   - ✅ App usable without sign-in
   - ✅ Smooth onboarding experience
   - ✅ Preview functionality before committing to account

### Concurrency/Data Consistency

- **Batch Writes**: Delete and reorder operations use `batch.commit()` for atomic multi-document updates
  ```kotlin
  val batch = db.batch()
  batch.delete(toDelete.reference)
  items.forEachIndexed { i, (snap, _) ->
    batch.update(snap.reference, mapOf("order" to i.toLong()))
  }
  Tasks.await(batch.commit())  // Atomic: all succeed or all fail
  ```

- **Server Timestamps**: `FieldValue.serverTimestamp()` ensures consistent timestamps across clients regardless of device clock

- **Order Preservation**: `orderBy("order", ASCENDING)` guarantees consistent ordering across queries

### Performance Considerations

- **Single Query Per Load**: Fetches all objectives in one query: `col().orderBy("order").get()`
- **Indexed Queries**: Firestore auto-creates index for `order` field (no manual index configuration needed)
- **Coroutine-Based I/O**: All Firestore operations run on `Dispatchers.IO` to avoid blocking main thread
- **Lazy Loading**: ViewModel uses `StateFlow` so UI only recomposes when data actually changes
- **No Overfetching**: Day filtering happens in ViewModel (client-side) after fetch—future optimization could use Firestore `where("day", "==", "MONDAY")` query

## Testing

### Unit Tests

**File**: `FirestoreObjectivesRepositoryTest.kt`

- ✅ `getObjectives_unsigned_returnsDefaultsInOrder()` - Verifies 13 default objectives with correct courses and days
- ✅ `addObjective_unsigned_appends()` - Tests adding objective to defaults (14 total)
- ✅ `updateObjective_unsigned_replaces_at_index()` - Tests toggling completion status
- ✅ `removeObjective_unsigned_deletes_and_compacts()` - Tests deletion and index compaction (12 remaining)
- ✅ `moveObjective_unsigned_reorders()` - Tests custom reordering logic
- ✅ `setObjectives_unsigned_replaces_all()` - Tests bulk replacement
- ✅ `update_remove_move_outOfRange_unsigned_are_noops()` - Edge cases with invalid indices

**Coverage**: All unsigned (fallback) paths tested. Firestore-connected paths tested via emulator tests.

### UI/Instrumented Tests

**File**: `WeekProgDailyObjTest.kt`

- ✅ `objectives_onlyShowsTodaysObjectives_notOtherDays()` - Verifies day filtering: sets objectives for today + tomorrow, confirms only today's render, tomorrow's are hidden
- ✅ `objectives_showsSingularHeader_whenOnlyOneTodayObjective()` - Tests singular "Today's Objective" header and no "Show all" button
- ✅ `objectives_emptyState_rendersWhenNoObjectives()` - Tests empty state message when no objectives for selected day

**File**: `FirestoreObjectivesRepositoryEmulatorTest.kt`

- ✅ Tests full CRUD operations against Firestore emulator
- ✅ Verifies order preservation after add/remove/move operations
- ✅ Tests batch operations for atomicity

### Manual Testing

| Test Case | Steps | Expected Result | Status |
|-----------|-------|-----------------|--------|
| New user sign-in | 1. Create new account<br>2. Open schedule | 13 default objectives seeded to Firestore, distributed across week | ✅ |
| Day filtering | 1. Tap Monday in schedule<br>2. Tap Thursday | Monday: shows 2 objectives (Quiz, Reading)<br>Thursday: shows 3 objectives | ✅ |
| Mark complete | 1. Tap "Start" on objective<br>2. Check Firestore console | `completed: true` in Firestore, checkmark in UI | ✅ |
| Persistence | 1. Mark objective complete<br>2. Force-quit app<br>3. Reopen | Completion status persists, same objectives load | ✅ |
| Multi-device sync | 1. Sign in on device A<br>2. Add objective<br>3. Sign in on device B<br>4. Pull to refresh | Objective appears on device B | ✅ |

## Screenshots / Demos

### Before: Fake Repository
- ❌ Objectives lost on app restart
- ❌ No day-based filtering
- ❌ No cloud sync

### After: Firestore Integration

**Schedule - Monday (2 Objectives)**
```
┌─────────────────────────────────────┐
│  📅 Monday, December 2, 2025       │
├─────────────────────────────────────┤
│  Today's Objectives                 │
│                                     │
│  ○ Complete Quiz 1                  │
│     CS-200 • 30m                    │
│     [▶ Start]                       │
│                                     │
│  ○ Read Chapter 1                   │
│     CS-200 • 45m                    │
│     [▶ Start]                       │
└─────────────────────────────────────┘
```

**Schedule - Thursday (3 Objectives)**
```
┌─────────────────────────────────────┐
│  📅 Thursday, December 5, 2025     │
├─────────────────────────────────────┤
│  Today's Objectives                 │
│                                     │
│  ○ Reading Assignment               │
│     SHS-150 • 45m                   │
│     [▶ Start]                       │
│                                     │
│  ○ Essay Outline                    │
│     SHS-150 • 30m                   │
│     [▶ Start]                       │
│                                     │
│  ○ Discussion Forum Post            │
│     SHS-150 • 15m                   │
│     [▶ Start]                       │
│                                     │
│  [Show all (3)]                     │
└─────────────────────────────────────┘
```

**Firestore Console**
```
users/
  └─ abc123xyz/
      └─ objectives/
          ├─ doc1: { title: "Complete Quiz 1", day: "MONDAY", completed: false, order: 0 }
          ├─ doc2: { title: "Read Chapter 1", day: "MONDAY", completed: false, order: 1 }
          ├─ doc3: { title: "Solve Exercise Set 1", day: "TUESDAY", completed: false, order: 2 }
          └─ ... (13 total)
```

**Device**: Pixel 5 Emulator  
**API Level**: 34 (Android 14)

## Checklist

- [x] Firestore repository implements full ObjectivesRepository interface
- [x] All CRUD operations (get/add/update/delete/move/set) working
- [x] Day-based filtering implemented in schedule screen
- [x] Completion status syncs to Firebase on toggle
- [x] Start button marks complete and navigates to correct screen
- [x] Default objectives seed automatically for new users
- [x] Unit tests pass for unsigned fallback path
- [x] UI tests verify day filtering logic
- [x] Emulator tests verify Firestore operations
- [x] Manual testing on emulator and real device
- [x] SonarCloud issues resolved (string duplication)
- [x] No breaking changes to existing interfaces
- [x] Code reviewed for clarity and maintainability
- [x] Firestore security rules updated (user can only access own objectives)

## Notes

### Default Objectives Distribution

The 13 default objectives are distributed as follows:
- **Monday**: 2 objectives (CS-200: Quiz + Reading)
- **Tuesday**: 2 objectives (CS-201: Exercises + Lecture Review)
- **Wednesday**: 2 objectives (COM-100: Lab + Quiz)
- **Thursday**: 3 objectives (SHS-150: Reading + Essay + Forum Post)
- **Friday**: 2 objectives (CS-100: Problem Set + Quiz)
- **Saturday**: 1 objective (CS-200: Review Material)
- **Sunday**: 1 objective (COM-100: Midterm Prep)

### String Constants Refactoring

Extracted course code constants to fix SonarCloud duplication issues:
```kotlin
private const val COURSE_CS_200 = "CS-200"   // Used 3 times
private const val COURSE_CS_201 = "CS-201"   // Used 2 times
private const val COURSE_COM_100 = "COM-100" // Used 3 times
private const val COURSE_SHS_150 = "SHS-150" // Used 3 times
private const val COURSE_CS_100 = "CS-100"   // Used 2 times
```

### Future Enhancements

- Add Firestore real-time listeners for instant multi-device sync
- Implement offline persistence with Firestore cache
- Add push notifications for objectives due today
- Analytics: track completion rates by day/course
- Drag-and-drop UI for custom reordering

## Issue Reference

Closes #163 