### PR TITLE
fix(gradle) : first fix

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -194,18 +194,10 @@ dependencies {
 }
 
 tasks.withType<Test> {
-    // Jacoco for unit tests (avoid instrumenting JDK classes on Java 21+)
+    // Jacoco for unit tests
     configure<JacocoTaskExtension> {
-        isIncludeNoLocationClasses = false // was true; this caused JaCoCo to try to instrument JDK classes
-        excludes = listOf(
-            "jdk.*",
-            "java.*",
-            "javax.*",
-            "sun.*",
-            "com.sun.*",
-            "org.jacoco.*",
-            "kotlin.*"
-        )
+        isIncludeNoLocationClasses = true
+        excludes = listOf("jdk.internal.*")
     }
 }
 


### PR DESCRIPTION
Fixing the `buidl.gradle.kts` file that caused some tests to be skipped or excluded

Closes #214 