### PR TITLE
feat(notifications): implement campus entry notification

### DIFF
--- a/app/src/main/java/com/android/sample/data/notifications/CampusEntryPollWorker.kt
+++ b/app/src/main/java/com/android/sample/data/notifications/CampusEntryPollWorker.kt
@@ -211,7 +211,7 @@ class CampusEntryPollWorker(appContext: Context, params: WorkerParameters) :
    * Post a notification informing the user they have entered campus. Requires POST_NOTIFICATIONS
    * permission on Android 13+.
    */
-  @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
+  @RequiresPermission("android.permission.POST_NOTIFICATIONS")
   private fun postCampusEntryNotification(ctx: Context) {
     NotificationUtils.ensureChannel(ctx)
 

--- a/app/src/main/java/com/android/sample/data/notifications/CampusEntryPollWorker.kt
+++ b/app/src/main/java/com/android/sample/data/notifications/CampusEntryPollWorker.kt
@@ -208,8 +208,8 @@ class CampusEntryPollWorker(appContext: Context, params: WorkerParameters) :
   }
 
   /**
-   * Post a notification informing the user they have entered campus. Requires
-   * POST_NOTIFICATIONS permission on Android 13+.
+   * Post a notification informing the user they have entered campus. Requires POST_NOTIFICATIONS
+   * permission on Android 13+.
    */
   @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
   private fun postCampusEntryNotification(ctx: Context) {

--- a/app/src/main/java/com/android/sample/data/notifications/NotificationUtils.kt
+++ b/app/src/main/java/com/android/sample/data/notifications/NotificationUtils.kt
@@ -11,7 +11,8 @@ object NotificationUtils {
   // IDs stables pour nos notifications
   const val TEST_NOTIFICATION_ID = 1001
   const val ID_KEEP_STREAK = 1002
-  const val ID_STUDY_KICKOFF = 1003 // ✅ ajoute celui-ci
+  const val ID_STUDY_KICKOFF = 1003
+  const val ID_CAMPUS_ENTRY = 1004
 
   fun ensureChannel(ctx: Context) {
     val mgr = ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -312,6 +312,7 @@
     <string name="study_together_no_friends_yet">No friends yet</string>
 
     <string name="campus_entry_title">Welcome to campus</string>
+    <string name="campus_entry_text">You have arrived on campus</string>
     <string name="campus_entry_toggle_title">Campus entry notifications</string>
     <string name="campus_entry_toggle_subtitle">Notify when you arrive on campus (every entry)</string>
 


### PR DESCRIPTION
## Summary
This PR is introducing a notification popping up when the user enters the campus

## What’s in this PR
- Notification logic
- Enhancement of existing logic to welcome notification logic

## Implementation Notes
- Use of the existing Worker for background location
- Addition of notification triggering logic in the worker

## Testing
- Unit: none
- UI/Instrumented: Notification flow

## Screenshots / Demos
Screenshot will be added here if opportunity to test the app irl.

## Checklist
- [x] Sends a notification when the student just entered the campus

## Notes
This feature is to be tested in real life to display the changes properly.

## Issue Reference
Closes #196 

