### PR TITLE
Feat(schedule): fix today's classes logic

### DIFF
--- a/app/src/androidTest/java/com/android/sample/schedule/DayTabContentModalTest.kt
+++ b/app/src/androidTest/java/com/android/sample/schedule/DayTabContentModalTest.kt
@@ -1,6 +1,10 @@
 package com.android.sample.schedule
 
 import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
@@ -122,7 +126,11 @@ class DayTabContentAllAndroidTest {
     val clazz = fakeClass("c9", "AI")
     val state = ScheduleUiState(todayClasses = listOf(clazz))
 
-    rule.setContent { DayTabContent(vm, state, ObjectivesViewModel(requireAuth = false)) }
+    rule.setContent {
+      Column(Modifier.verticalScroll(rememberScrollState())) {
+        DayTabContent(vm, state, ObjectivesViewModel(requireAuth = false))
+      }
+    }
 
     rule
         .onNodeWithText(ctx.getString(R.string.wellness_events_label))
@@ -147,7 +155,11 @@ class DayTabContentAllAndroidTest {
         ScheduleUiState(
             todayClasses = emptyList(), attendanceRecords = emptyList(), todos = emptyList())
 
-    rule.setContent { DayTabContent(vm, state, ObjectivesViewModel(requireAuth = false)) }
+    rule.setContent {
+      Column(Modifier.verticalScroll(rememberScrollState())) {
+        DayTabContent(vm, state, ObjectivesViewModel(requireAuth = false))
+      }
+    }
 
     rule
         .onNodeWithText(ctx.getString(R.string.schedule_day_todos_title))
@@ -196,7 +208,10 @@ class DayTabContentAllAndroidTest {
     val vm = buildScheduleVM(ctx)
 
     rule.setContent {
-      DayTabContent(vm = vm, state = state, objectivesVm = ObjectivesViewModel(requireAuth = false))
+      Column(Modifier.verticalScroll(rememberScrollState())) {
+        DayTabContent(
+            vm = vm, state = state, objectivesVm = ObjectivesViewModel(requireAuth = false))
+      }
     }
 
     val dateText = LocalDate.now().format(DateTimeFormatter.ofPattern("EEEE, MMM d"))
@@ -310,7 +325,10 @@ class DayTabContentAllAndroidTest {
     val state = ScheduleUiState(todayClasses = listOf(clazz))
 
     rule.setContent {
-      DayTabContent(vm = vm, state = state, objectivesVm = ObjectivesViewModel(requireAuth = false))
+      Column(Modifier.verticalScroll(rememberScrollState())) {
+        DayTabContent(
+            vm = vm, state = state, objectivesVm = ObjectivesViewModel(requireAuth = false))
+      }
     }
 
     // Scroll to the Wellness section header first
@@ -357,7 +375,10 @@ class DayTabContentAllAndroidTest {
             todayClasses = emptyList(), attendanceRecords = emptyList(), todos = emptyList())
 
     rule.setContent {
-      DayTabContent(vm = vm, state = state, objectivesVm = ObjectivesViewModel(requireAuth = false))
+      Column(Modifier.verticalScroll(rememberScrollState())) {
+        DayTabContent(
+            vm = vm, state = state, objectivesVm = ObjectivesViewModel(requireAuth = false))
+      }
     }
 
     val title = ctx.getString(R.string.schedule_day_todos_title)
@@ -395,7 +416,10 @@ class DayTabContentAllAndroidTest {
             todos = listOf(todayTodo, tomorrowTodo))
 
     rule.setContent {
-      DayTabContent(vm = vm, state = state, objectivesVm = ObjectivesViewModel(requireAuth = false))
+      Column(Modifier.verticalScroll(rememberScrollState())) {
+        DayTabContent(
+            vm = vm, state = state, objectivesVm = ObjectivesViewModel(requireAuth = false))
+      }
     }
 
     // Only today's task should appear in the "Today's To-Dos" section

--- a/app/src/androidTest/java/com/android/sample/schedule/WeekTabContentTest.kt
+++ b/app/src/androidTest/java/com/android/sample/schedule/WeekTabContentTest.kt
@@ -248,29 +248,31 @@ class WeekTabContentAllAndroidTest {
     val selected = LocalDate.of(2025, 5, 7)
 
     rule.setContent {
-      WeekTabContent(
-          vm = vm,
-          objectivesVm = objectivesVm,
-          allTasks = tasksForWeek(selected),
-          selectedDate = selected,
-          weekTodos = emptyList())
+      Column(Modifier.verticalScroll(rememberScrollState())) {
+        WeekTabContent(
+            vm = vm,
+            objectivesVm = objectivesVm,
+            allTasks = tasksForWeek(selected),
+            selectedDate = selected,
+            weekTodos = emptyList())
+      }
     }
 
     // header
     val upcoming = rule.activity.getString(R.string.upcoming_events)
-    rule.onNodeWithText(upcoming).assertIsDisplayed()
+    rule.onNodeWithText(upcoming).performScrollTo().assertIsDisplayed()
 
     // inside-week items visible
-    rule.onAllNodesWithText("Linear Algebra review").onFirst().assertIsDisplayed()
-    rule.onAllNodesWithText("Part-time shift").onFirst().assertIsDisplayed()
-    rule.onAllNodesWithText("Gym with Sam").onFirst().assertIsDisplayed()
+    rule.onAllNodesWithText("Linear Algebra review").onFirst().performScrollTo().assertIsDisplayed()
+    rule.onAllNodesWithText("Part-time shift").onFirst().performScrollTo().assertIsDisplayed()
+    rule.onAllNodesWithText("Gym with Sam").onFirst().performScrollTo().assertIsDisplayed()
 
     // outside-week item not shown
     rule.onNodeWithText("Outside week task").assertDoesNotExist()
 
     // add button is there
     val addEvent = rule.activity.getString(R.string.add_event)
-    rule.onNodeWithText(addEvent).assertIsDisplayed()
+    rule.onNodeWithText(addEvent).performScrollTo().assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/sample/schedule/WeekTabContentTest.kt
+++ b/app/src/androidTest/java/com/android/sample/schedule/WeekTabContentTest.kt
@@ -2,6 +2,10 @@ package com.android.sample.schedule
 
 import android.content.Context
 import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -46,8 +50,7 @@ class WeekTabContentAllAndroidTest {
 
   @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
 
-  // ---------- Simple in-memory fakes ----------
-
+  // ... (Fakes and Helpers unchanged) ...
   private class InMemoryScheduleRepo(initial: List<ScheduleEvent> = emptyList()) :
       ScheduleRepository {
     private val _events = MutableStateFlow(initial)
@@ -302,12 +305,14 @@ class WeekTabContentAllAndroidTest {
     val weekStart = vm.startOfWeek(selected)
 
     rule.setContent {
-      WeekTabContent(
-          vm = vm,
-          objectivesVm = objectivesVm,
-          allTasks = tasksForWeek(selected),
-          selectedDate = selected,
-          weekTodos = emptyList())
+      Column(Modifier.verticalScroll(rememberScrollState())) {
+        WeekTabContent(
+            vm = vm,
+            objectivesVm = objectivesVm,
+            allTasks = tasksForWeek(selected),
+            selectedDate = selected,
+            weekTodos = emptyList())
+      }
     }
 
     val ctx = rule.activity
@@ -328,17 +333,19 @@ class WeekTabContentAllAndroidTest {
     val filteredWeekTodos = allWeekTodos.filter { it.dueDate in weekStart..weekStart.plusDays(6) }
 
     rule.setContent {
-      WeekTabContent(
-          vm = vm,
-          objectivesVm = objectivesVm,
-          allTasks = tasksForWeek(selected),
-          selectedDate = selected,
-          weekTodos = filteredWeekTodos)
+      Column(Modifier.verticalScroll(rememberScrollState())) {
+        WeekTabContent(
+            vm = vm,
+            objectivesVm = objectivesVm,
+            allTasks = tasksForWeek(selected),
+            selectedDate = selected,
+            weekTodos = filteredWeekTodos)
+      }
     }
 
     // Both inside-week todos should be visible; outside-week one is not passed in
-    rule.onNodeWithText("Week todo 1", substring = false).assertIsDisplayed()
-    rule.onNodeWithText("Week todo 2", substring = false).assertIsDisplayed()
+    rule.onNodeWithText("Week todo 1", substring = false).performScrollTo().assertIsDisplayed()
+    rule.onNodeWithText("Week todo 2", substring = false).performScrollTo().assertIsDisplayed()
     rule.onNodeWithText("Outside week todo", substring = false).assertDoesNotExist()
   }
 

--- a/app/src/androidTest/java/com/android/sample/screen/FirestorePlannerRepositoryEmulatorTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/FirestorePlannerRepositoryEmulatorTest.kt
@@ -348,7 +348,7 @@ class FirestorePlannerRepositoryEmulatorTest {
             location = "LAB-X",
             instructor = "Prof. Turing")
 
-    val result = repo.saveClass(classItem)
+    val result = repo.saveClasses(listOf(classItem))
     assertTrue("saveClass() should succeed", result.isSuccess)
 
     // Snapshot listener needs a moment to update

--- a/app/src/androidTest/java/com/android/sample/screen/FirestorePlannerRepositoryEmulatorTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/FirestorePlannerRepositoryEmulatorTest.kt
@@ -3,6 +3,7 @@ package com.android.sample.screen
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.sample.feature.schedule.data.planner.AttendanceStatus
+import com.android.sample.feature.schedule.data.planner.Class
 import com.android.sample.feature.schedule.data.planner.ClassAttendance
 import com.android.sample.feature.schedule.data.planner.ClassType
 import com.android.sample.feature.schedule.data.planner.CompletionStatus
@@ -12,6 +13,7 @@ import com.google.android.gms.tasks.Tasks
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
+import java.util.UUID
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -48,6 +50,62 @@ class FirestorePlannerRepositoryEmulatorTest {
     if (FirebaseEmulator.isRunning) {
       FirebaseEmulator.clearAll()
     }
+  }
+
+  @Test
+  fun saveClasses_and_clearClasses_work_correctly() = runBlocking {
+    val c1 =
+        Class(
+            UUID.randomUUID().toString(),
+            "Batch 1",
+            LocalTime.now(),
+            LocalTime.now(),
+            ClassType.LAB)
+    val c2 =
+        Class(
+            UUID.randomUUID().toString(),
+            "Batch 2",
+            LocalTime.now(),
+            LocalTime.now(),
+            ClassType.LECTURE)
+
+    // Test Batch Save
+    val saveResult = repo.saveClasses(listOf(c1, c2))
+    assertTrue(saveResult.isSuccess)
+
+    val loaded = repo.getTodayClassesFlow().first()
+    assertTrue(loaded.any { it.courseName == "Batch 1" })
+    assertTrue(loaded.any { it.courseName == "Batch 2" })
+
+    // Test Clear
+    val clearResult = repo.clearClasses()
+    assertTrue(clearResult.isSuccess)
+
+    val loadedAfterClear = repo.getTodayClassesFlow().first()
+    assertTrue("Classes should be empty after clear", loadedAfterClear.isEmpty())
+  }
+
+  @Test
+  fun getTodayClassesFlow_read_from_firestore_when_docs_exist() = runBlocking {
+    val db = FirebaseEmulator.firestore
+    val uid = FirebaseEmulator.auth.currentUser!!.uid
+    val today = LocalDate.now()
+
+    val classesCol = db.collection("users").document(uid).collection("classes")
+
+    Tasks.await(
+        classesCol.add(
+            mapOf(
+                "courseName" to "Networks",
+                "startTime" to LocalTime.of(14, 0).toString(),
+                "endTime" to LocalTime.of(16, 0).toString(),
+                "type" to ClassType.LAB.name,
+                "location" to "Lab A",
+                "instructor" to "Prof. Davis",
+                "date" to today.toString())))
+
+    val classes = repo.getTodayClassesFlow().first()
+    assertTrue(classes.any { it.courseName == "Networks" })
   }
 
   @Test

--- a/app/src/main/java/com/android/sample/MainActivity.kt
+++ b/app/src/main/java/com/android/sample/MainActivity.kt
@@ -8,18 +8,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import com.android.sample.ui.login.LoginScreen
 import com.android.sample.ui.theme.EduMonTheme
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
@@ -29,13 +21,16 @@ class MainActivity : ComponentActivity() {
 
   private val auth: FirebaseAuth by lazy { FirebaseAuth.getInstance() }
 
-  override fun onCreate(savedInstanceState: Bundle?) { // <-- @OptIn removed
+  override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    // Capture the intent data (deep link) if present
-    val startUri: Uri? = intent?.data
+    // ⭐ SIGN IN BEFORE ANY UI OR REPOSITORY INITIALIZATION
+    if (auth.currentUser == null) {
+      auth.signInAnonymously()
+    }
 
-    // Compute start destination based on deep link
+    // Deep link handling
+    val startUri: Uri? = intent?.data
     val (startRoute, _) =
         if (startUri?.scheme == "edumon" && startUri.host == "study_session") {
           val id = startUri.pathSegments.firstOrNull()
@@ -46,40 +41,12 @@ class MainActivity : ComponentActivity() {
     setContent {
       EduMonTheme {
         val nav = rememberNavController()
-        var user by remember { mutableStateOf(auth.currentUser) }
-        val scope = rememberCoroutineScope()
 
-        DisposableEffect(Unit) {
-          val l =
-              FirebaseAuth.AuthStateListener { fa ->
-                val u = fa.currentUser
-                val goTo = if (u == null) "login" else "app"
-                user = u
-                nav.navigate(goTo) {
-                  popUpTo(nav.graph.startDestinationId) { inclusive = true }
-                  launchSingleTop = true
-                }
-              }
-          auth.addAuthStateListener(l)
-          onDispose { auth.removeAuthStateListener(l) }
-        }
-
-        // ⬇ Scaffold without topBar
         Scaffold { padding ->
           Box(Modifier.fillMaxSize().padding(padding)) {
-            NavHost(navController = nav, startDestination = if (user == null) "login" else "app") {
-              composable("login") {
-                LoginScreen(
-                    onLoggedIn = {
-                      nav.navigate("app") {
-                        popUpTo("login") { inclusive = true }
-                        launchSingleTop = true
-                      }
-                    })
-              }
-
+            NavHost(navController = nav, startDestination = "app") {
               composable("app") {
-                LaunchedEffect(user?.uid) { user?.let { try {} catch (_: Exception) {} } }
+                // auth is already guaranteed non-null here
                 EduMonNavHost(startDestination = startRoute)
               }
             }

--- a/app/src/main/java/com/android/sample/feature/schedule/data/planner/PlannerData.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/data/planner/PlannerData.kt
@@ -8,6 +8,7 @@ import com.android.sample.ui.theme.EventColorMusic
 import com.android.sample.ui.theme.EventColorSocial
 import com.android.sample.ui.theme.EventColorSports
 import com.android.sample.ui.theme.EventColorYoga
+import java.time.DayOfWeek
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
@@ -20,7 +21,8 @@ data class Class(
     val endTime: LocalTime,
     val type: ClassType,
     val location: String = "",
-    val instructor: String = ""
+    val instructor: String = "",
+    val daysOfWeek: List<DayOfWeek> = DayOfWeek.values().toList()
 )
 
 enum class ClassType {

--- a/app/src/main/java/com/android/sample/feature/schedule/repository/planner/FirestorePlannerRepository.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/repository/planner/FirestorePlannerRepository.kt
@@ -140,6 +140,25 @@ class FirestorePlannerRepository(
     }
   }
 
+  override suspend fun saveClasses(classes: List<Class>): Result<Unit> {
+    val uid = auth.currentUser?.uid ?: return Result.failure(Exception("Not logged in"))
+
+    return try {
+      val batch = db.batch()
+      val collectionRef = userPlannerClassesRef(uid)
+
+      classes.forEach { classItem ->
+        val docRef = collectionRef.document(classItem.id)
+        batch.set(docRef, classItem.toFirestoreMap(), SetOptions.merge())
+      }
+
+      batch.commit().await()
+      Result.success(Unit)
+    } catch (e: Exception) {
+      Result.failure(e)
+    }
+  }
+
   override suspend fun clearClasses(): Result<Unit> {
     val uid = auth.currentUser?.uid ?: return Result.failure(Exception("Not logged in"))
 

--- a/app/src/main/java/com/android/sample/feature/schedule/repository/planner/FirestorePlannerRepository.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/repository/planner/FirestorePlannerRepository.kt
@@ -9,6 +9,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.SetOptions
+import java.time.DayOfWeek
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
@@ -138,6 +139,28 @@ class FirestorePlannerRepository(
       Result.failure(e)
     }
   }
+
+  override suspend fun clearClasses(): Result<Unit> {
+    val uid = auth.currentUser?.uid ?: return Result.failure(Exception("Not logged in"))
+
+    return try {
+      // 1. Get all documents in the classes collection
+      val snapshot = userPlannerClassesRef(uid).get().await()
+
+      // 2. Create a batch to delete them all at once (more efficient)
+      val batch = db.batch()
+      for (doc in snapshot.documents) {
+        batch.delete(doc.reference)
+      }
+
+      // 3. Commit the delete
+      batch.commit().await()
+
+      Result.success(Unit)
+    } catch (e: Exception) {
+      Result.failure(e)
+    }
+  }
 }
 
 /* ---------- Mapping helpers ---------- */
@@ -147,6 +170,19 @@ private fun DocumentSnapshot.toPlannerClass(): Class? {
   val startStr = getString("startTime") ?: return null
   val endStr = getString("endTime") ?: return null
   val typeStr = getString("type") ?: ClassType.LECTURE.name
+  val daysList = get("daysOfWeek") as? List<String>
+  val daysOfWeek =
+      if (daysList != null) {
+        daysList.mapNotNull { runCatching { DayOfWeek.valueOf(it) }.getOrNull() }
+      } else {
+        // Fallback: If "dayOfWeek" (singular) exists, use it. Otherwise, assume every day.
+        val singleDay = getString("dayOfWeek")
+        if (singleDay != null) {
+          listOfNotNull(runCatching { DayOfWeek.valueOf(singleDay) }.getOrNull())
+        } else {
+          DayOfWeek.values().toList()
+        }
+      }
 
   val startTime = runCatching { LocalTime.parse(startStr) }.getOrNull() ?: return null
   val endTime = runCatching { LocalTime.parse(endStr) }.getOrNull() ?: startTime
@@ -163,7 +199,8 @@ private fun DocumentSnapshot.toPlannerClass(): Class? {
       endTime = endTime,
       type = type,
       location = location,
-      instructor = instructor)
+      instructor = instructor,
+      daysOfWeek = daysOfWeek)
 }
 
 private fun DocumentSnapshot.toClassAttendance(): ClassAttendance? {
@@ -205,4 +242,5 @@ private fun Class.toFirestoreMap(): Map<String, Any?> =
         "endTime" to endTime.toString(),
         "type" to type.name,
         "location" to location,
-        "instructor" to instructor)
+        "instructor" to instructor,
+        "daysOfWeek" to daysOfWeek.map { it.name })

--- a/app/src/main/java/com/android/sample/feature/schedule/repository/planner/FirestorePlannerRepository.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/repository/planner/FirestorePlannerRepository.kt
@@ -125,21 +125,6 @@ class FirestorePlannerRepository(
     }
   }
 
-  override suspend fun saveClass(classItem: Class): Result<Unit> {
-    val uid = auth.currentUser?.uid ?: return Result.failure(Exception("Not logged in"))
-
-    return try {
-      userPlannerClassesRef(uid)
-          .document(classItem.id)
-          .set(classItem.toFirestoreMap(), SetOptions.merge())
-          .await()
-
-      Result.success(Unit)
-    } catch (e: Exception) {
-      Result.failure(e)
-    }
-  }
-
   override suspend fun saveClasses(classes: List<Class>): Result<Unit> {
     val uid = auth.currentUser?.uid ?: return Result.failure(Exception("Not logged in"))
 

--- a/app/src/main/java/com/android/sample/feature/schedule/repository/planner/PlannerRepository.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/repository/planner/PlannerRepository.kt
@@ -91,5 +91,7 @@ open class PlannerRepository {
     return Result.failure(Exception("Not implemented"))
   }
 
+  open suspend fun saveClasses(classes: List<Class>): Result<Unit> = Result.success(Unit)
+
   open suspend fun clearClasses(): Result<Unit> = Result.success(Unit)
 }

--- a/app/src/main/java/com/android/sample/feature/schedule/repository/planner/PlannerRepository.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/repository/planner/PlannerRepository.kt
@@ -87,10 +87,6 @@ open class PlannerRepository {
                 timestamp = Instant.now()))
   }
 
-  open suspend fun saveClass(classItem: Class): Result<Unit> {
-    return Result.failure(Exception("Not implemented"))
-  }
-
   open suspend fun saveClasses(classes: List<Class>): Result<Unit> = Result.success(Unit)
 
   open suspend fun clearClasses(): Result<Unit> = Result.success(Unit)

--- a/app/src/main/java/com/android/sample/feature/schedule/repository/planner/PlannerRepository.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/repository/planner/PlannerRepository.kt
@@ -90,4 +90,6 @@ open class PlannerRepository {
   open suspend fun saveClass(classItem: Class): Result<Unit> {
     return Result.failure(Exception("Not implemented"))
   }
+
+  open suspend fun clearClasses(): Result<Unit> = Result.success(Unit)
 }

--- a/app/src/main/java/com/android/sample/feature/schedule/repository/schedule/IcsImporter.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/repository/schedule/IcsImporter.kt
@@ -13,6 +13,7 @@ class IcsImporter(private val plannerRepository: PlannerRepository, context: Con
   private val matcher = KeywordMatcher(context)
 
   suspend fun importFromStream(stream: InputStream) {
+    val classesToSave = mutableListOf<Class>()
     plannerRepository.clearClasses()
     val classes = IcsParser.parse(stream)
     val groupedClasses = classes.groupBy { CourseIdentity(it.title, it.start, it.end, it.location) }
@@ -33,8 +34,9 @@ class IcsImporter(private val plannerRepository: PlannerRepository, context: Con
               location = c.location ?: "",
               instructor = extractInstructor(representative.description),
               daysOfWeek = daysOfWeek)
-      plannerRepository.saveClass(classItem)
+      classesToSave.add(classItem)
     }
+    plannerRepository.saveClasses(classesToSave)
   }
 
   private fun mapClassType(c: IcsParser.IcsClass): ClassType {

--- a/app/src/main/java/com/android/sample/feature/schedule/viewmodel/ScheduleViewModel.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/viewmodel/ScheduleViewModel.kt
@@ -76,16 +76,18 @@ class ScheduleViewModel(
       launch {
         plannerRepository.getTodayClassesFlow().collect { classes ->
           val now = LocalTime.now()
+          val todayDay = LocalDate.now().dayOfWeek
+          val todayClasses = classes.filter { it.daysOfWeek.contains(todayDay) }
 
           val deduped =
-              classes
+              todayClasses
                   .groupBy { Triple(it.courseName, it.startTime, it.endTime) }
                   .map { (_, group) -> group.first() }
 
           val upcoming = deduped.filter { cls -> cls.endTime.isAfter(now) }
 
           val sorted = upcoming.sortedBy { it.startTime }
-          val allFinished = deduped.all { cls -> cls.endTime.isBefore(now) }
+          val allFinished = deduped.isNotEmpty() && deduped.all { cls -> cls.endTime.isBefore(now) }
 
           _uiState.update { it.copy(todayClasses = sorted, allClassesFinished = allFinished) }
         }

--- a/app/src/main/java/com/android/sample/ui/schedule/DayTabContent.kt
+++ b/app/src/main/java/com/android/sample/ui/schedule/DayTabContent.kt
@@ -76,8 +76,8 @@ fun DayTabContent(
   }
 
   Column(
-      modifier = Modifier.fillMaxSize().padding(bottom = 96.dp),
-      verticalArrangement = Arrangement.spacedBy(16.dp)) {
+      modifier = Modifier.fillMaxSize().padding(bottom = Dimensions.bottomBarPadding),
+      verticalArrangement = Arrangement.spacedBy(Dimensions.spacingLarge)) {
         val today = LocalDate.now()
         val dayTodos = state.todos.filter { it.dueDate == today }
         TodayCard(
@@ -118,8 +118,8 @@ private fun TodayCard(
         style =
             MaterialTheme.typography.titleMedium.copy(
                 fontWeight = FontWeight.Bold, fontSize = 20.sp, color = cs.onSurface),
-        modifier = Modifier.padding(bottom = 6.dp))
-    Spacer(Modifier.height(12.dp))
+        modifier = Modifier.padding(bottom = Dimensions.spacingXSmall))
+    Spacer(Modifier.height(Dimensions.spacingMedium))
 
     // ---- Classes section (card inside card) ----
     SectionBox(
@@ -131,7 +131,7 @@ private fun TodayCard(
                       fontSize = 18.sp,
                       fontWeight = FontWeight.SemiBold,
                       color = MaterialTheme.colorScheme.onSurface),
-              modifier = Modifier.padding(bottom = 8.dp))
+              modifier = Modifier.padding(bottom = Dimensions.spacingSmall))
         }) {
           when {
             (classes.isEmpty() && !allClassesFinished) -> {
@@ -144,10 +144,10 @@ private fun TodayCard(
               Box(
                   modifier =
                       Modifier.fillMaxWidth()
-                          .padding(top = 12.dp)
-                          .clip(RoundedCornerShape(16.dp))
+                          .padding(top = Dimensions.spacingMedium)
+                          .clip(RoundedCornerShape(Dimensions.spacingLarge))
                           .background(CustomGreen.copy(alpha = 0.15f))
-                          .padding(16.dp),
+                          .padding(Dimensions.spacingLarge),
                   contentAlignment = Alignment.Center) {
                     Text(
                         text = stringResource(R.string.finished_classes),
@@ -201,7 +201,7 @@ private fun TodayCard(
               fontSize = 18.sp,
               fontWeight = FontWeight.SemiBold,
               color = cs.onSurface,
-              modifier = Modifier.padding(bottom = 8.dp))
+              modifier = Modifier.padding(bottom = Dimensions.spacingSmall))
         }) {
           if (todos.isEmpty()) {
             Text(
@@ -209,13 +209,13 @@ private fun TodayCard(
                 color = cs.onSurface.copy(alpha = 0.7f),
                 modifier = modifier.fillMaxWidth())
           } else {
-            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(Dimensions.spacingXSmall)) {
               todos.forEach { todo ->
                 Row(
                     modifier =
-                        Modifier.fillMaxWidth().padding(vertical = 6.dp).clickable {
-                          onTodoClicked(todo.id)
-                        }) {
+                        Modifier.fillMaxWidth()
+                            .padding(vertical = Dimensions.spacingXSmall)
+                            .clickable { onTodoClicked(todo.id) }) {
                       Box(
                           modifier =
                               Modifier.width(5.dp)
@@ -251,7 +251,7 @@ private fun TodayCard(
               style =
                   MaterialTheme.typography.titleMedium.copy(
                       fontSize = 18.sp, fontWeight = FontWeight.SemiBold, color = cs.onSurface),
-              modifier = Modifier.padding(bottom = 8.dp))
+              modifier = Modifier.padding(bottom = Dimensions.spacingSmall))
         }) {
           Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
             WellnessEventItem(
@@ -326,7 +326,8 @@ private fun CompactClassRow(clazz: Class, record: ClassAttendance?, modifier: Mo
 
     if (record != null) {
       Column(
-          horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+          horizontalAlignment = Alignment.End,
+          verticalArrangement = Arrangement.spacedBy(Dimensions.spacingSmall)) {
             // Attendance
             val attColor =
                 when (record.attendance) {
@@ -339,8 +340,8 @@ private fun CompactClassRow(clazz: Class, record: ClassAttendance?, modifier: Mo
                   painterResource(R.drawable.ic_check_circle),
                   null,
                   tint = attColor,
-                  modifier = Modifier.size(16.dp))
-              Spacer(Modifier.width(6.dp))
+                  modifier = Modifier.size(Dimensions.spacingLarge))
+              Spacer(Modifier.width(Dimensions.spacingXSmall))
               Text(
                   text =
                       when (record.attendance) {
@@ -365,8 +366,8 @@ private fun CompactClassRow(clazz: Class, record: ClassAttendance?, modifier: Mo
                   painterResource(R.drawable.ic_done_all),
                   null,
                   tint = compColor,
-                  modifier = Modifier.size(16.dp))
-              Spacer(Modifier.width(6.dp))
+                  modifier = Modifier.size(Dimensions.spacingLarge))
+              Spacer(Modifier.width(Dimensions.spacingXSmall))
               Text(
                   text =
                       when (record.completion) {

--- a/app/src/main/java/com/android/sample/ui/schedule/DayTabContent.kt
+++ b/app/src/main/java/com/android/sample/ui/schedule/DayTabContent.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -15,7 +14,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -77,25 +75,21 @@ fun DayTabContent(
         })
   }
 
-  LazyColumn(
-      modifier = Modifier.fillMaxSize(),
-      verticalArrangement = Arrangement.spacedBy(16.dp),
-      contentPadding = PaddingValues(bottom = 96.dp) // leave room for FAB
-      ) {
-        item {
-          val today = LocalDate.now()
-          val dayTodos = state.todos.filter { it.dueDate == today }
-          TodayCard(
-              classes = state.todayClasses,
-              attendance = state.attendanceRecords,
-              objectivesVm = objectivesVm,
-              onClassClick = { vm.onClassClicked(it) },
-              onObjectiveNavigate = onObjectiveNavigation,
-              todos = dayTodos,
-              onTodoClicked = onTodoClicked,
-              allClassesFinished = state.allClassesFinished,
-              modifier = Modifier.fillMaxWidth())
-        }
+  Column(
+      modifier = Modifier.fillMaxSize().padding(bottom = 96.dp),
+      verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        val today = LocalDate.now()
+        val dayTodos = state.todos.filter { it.dueDate == today }
+        TodayCard(
+            classes = state.todayClasses,
+            attendance = state.attendanceRecords,
+            objectivesVm = objectivesVm,
+            onClassClick = { vm.onClassClicked(it) },
+            onObjectiveNavigate = onObjectiveNavigation,
+            todos = dayTodos,
+            onTodoClicked = onTodoClicked,
+            allClassesFinished = state.allClassesFinished,
+            modifier = Modifier.fillMaxWidth())
       }
 }
 

--- a/app/src/main/java/com/android/sample/ui/schedule/Dimensions.kt
+++ b/app/src/main/java/com/android/sample/ui/schedule/Dimensions.kt
@@ -1,0 +1,12 @@
+package com.android.sample.ui.schedule
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+object Dimensions {
+  val spacingXSmall: Dp = 6.dp
+  val spacingSmall: Dp = 8.dp
+  val spacingMedium: Dp = 12.dp
+  val spacingLarge: Dp = 16.dp
+  val bottomBarPadding: Dp = 96.dp
+}

--- a/app/src/main/java/com/android/sample/ui/schedule/MonthTabContent.kt
+++ b/app/src/main/java/com/android/sample/ui/schedule/MonthTabContent.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,7 +12,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -53,105 +51,98 @@ fun MonthTabContent(
   val monthName = currentMonth.month.name.lowercase().replaceFirstChar { it.uppercase() }
   val headerTitle = stringResource(id = R.string.calendar_month_year, monthName, currentMonth.year)
 
-  LazyColumn(
+  Column(
       modifier = Modifier.fillMaxSize().testTag(MONTH_TAB_CONTENT),
       verticalArrangement = Arrangement.spacedBy(16.dp),
-      contentPadding = PaddingValues(bottom = 96.dp)) {
-        item("month-big-frame") {
+  ) {
+    // ONE AND ONLY big frame — like WeekTabContent
+    SectionBox(title = null, header = null) {
 
-          // ONE AND ONLY big frame — like WeekTabContent
-          SectionBox(title = null, header = null) {
+      // ───────────── Header ─────────────
+      CalendarHeader(
+          title = headerTitle, onPrevClick = onPreviousMonthClick, onNextClick = onNextMonthClick)
 
-            // ───────────── Header ─────────────
-            CalendarHeader(
-                title = headerTitle,
-                onPrevClick = { onPreviousMonthClick },
-                onNextClick = { onNextMonthClick })
+      Spacer(Modifier.height(8.dp))
 
-            Spacer(Modifier.height(8.dp))
-
-            // ───────────── Card with MonthGrid ─────────────
-            Card(
+      // ───────────── Card with MonthGrid ─────────────
+      Card(
+          modifier =
+              Modifier.fillMaxWidth()
+                  .shadow(8.dp, RoundedCornerShape(24.dp))
+                  .testTag(CalendarScreenTestTags.CALENDAR_CARD),
+          colors = CardDefaults.cardColors(containerColor = DarkBlue.copy(alpha = 0.85f)),
+          shape = RoundedCornerShape(24.dp)) {
+            Box(
                 modifier =
                     Modifier.fillMaxWidth()
-                        .shadow(8.dp, RoundedCornerShape(24.dp))
-                        .testTag(CalendarScreenTestTags.CALENDAR_CARD),
-                colors = CardDefaults.cardColors(containerColor = DarkBlue.copy(alpha = 0.85f)),
-                shape = RoundedCornerShape(24.dp)) {
-                  Box(
-                      modifier =
-                          Modifier.fillMaxWidth()
-                              .heightIn(min = 260.dp, max = 420.dp)
-                              .padding(horizontal = 8.dp, vertical = 6.dp)) {
-                        MonthGrid(
-                            currentMonth = currentMonth,
-                            selectedDate = selectedDate,
-                            allTasks = allTasks,
-                            onDateClick = { onDateSelected })
-                      }
+                        .heightIn(min = 260.dp, max = 420.dp)
+                        .padding(horizontal = 8.dp, vertical = 6.dp)) {
+                  MonthGrid(
+                      currentMonth = currentMonth,
+                      selectedDate = selectedDate,
+                      allTasks = allTasks,
+                      onDateClick = { onDateSelected })
                 }
+          }
 
-            Spacer(Modifier.height(16.dp))
+      Spacer(Modifier.height(16.dp))
 
-            // ───────────── Most important this month (HIGH priority only) ─────────────
-            val monthStart = currentMonth.atDay(1)
-            val monthEnd = monthStart.plusMonths(1).minusDays(1)
+      // ───────────── Most important this month (HIGH priority only) ─────────────
+      val monthStart = currentMonth.atDay(1)
+      val monthEnd = monthStart.plusMonths(1).minusDays(1)
 
-            val highPriorityMonthTasks =
-                allTasks
-                    .filter { it.date in monthStart..monthEnd && it.priority == Priority.HIGH }
-                    .distinctBy { it.id }
-                    .sortedWith(
-                        compareBy<StudyItem>({ it.date }, { it.time ?: java.time.LocalTime.MIN }))
+      val highPriorityMonthTasks =
+          allTasks
+              .filter { it.date in monthStart..monthEnd && it.priority == Priority.HIGH }
+              .distinctBy { it.id }
+              .sortedWith(compareBy<StudyItem>({ it.date }, { it.time ?: java.time.LocalTime.MIN }))
 
-            SectionBox(
-                header = {
-                  Text(
-                      text = stringResource(R.string.schedule_month_important_title),
-                      style =
-                          MaterialTheme.typography.titleMedium.copy(
-                              fontSize = 20.sp, fontWeight = FontWeight.Bold, color = Color.White),
-                      modifier = Modifier.fillMaxWidth().padding(bottom = 14.dp))
-                }) {
-                  val cs = MaterialTheme.colorScheme
+      SectionBox(
+          header = {
+            Text(
+                text = stringResource(R.string.schedule_month_important_title),
+                style =
+                    MaterialTheme.typography.titleMedium.copy(
+                        fontSize = 20.sp, fontWeight = FontWeight.Bold, color = Color.White),
+                modifier = Modifier.fillMaxWidth().padding(bottom = 14.dp))
+          }) {
+            val cs = MaterialTheme.colorScheme
 
-                  if (highPriorityMonthTasks.isEmpty()) {
-                    Text(
-                        text = stringResource(R.string.schedule_month_no_important),
-                        color = cs.onSurfaceVariant,
-                        modifier = Modifier.fillMaxWidth())
-                  } else {
+            if (highPriorityMonthTasks.isEmpty()) {
+              Text(
+                  text = stringResource(R.string.schedule_month_no_important),
+                  color = cs.onSurfaceVariant,
+                  modifier = Modifier.fillMaxWidth())
+            } else {
+              Column(modifier = Modifier.fillMaxWidth()) {
+                highPriorityMonthTasks.forEach { task ->
+                  Row(modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp)) {
+
+                    // small colored bar on the left
+                    Box(
+                        modifier =
+                            Modifier.width(5.dp)
+                                .height(32.dp)
+                                .background(cs.primary, RoundedCornerShape(999.dp)))
+
+                    Spacer(Modifier.width(10.dp))
+
                     Column(modifier = Modifier.fillMaxWidth()) {
-                      highPriorityMonthTasks.forEach { task ->
-                        Row(modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp)) {
-
-                          // small colored bar on the left
-                          Box(
-                              modifier =
-                                  Modifier.width(5.dp)
-                                      .height(32.dp)
-                                      .background(cs.primary, RoundedCornerShape(999.dp)))
-
-                          Spacer(Modifier.width(10.dp))
-
-                          Column(modifier = Modifier.fillMaxWidth()) {
-                            Text(
-                                text = task.title,
-                                style =
-                                    MaterialTheme.typography.bodyMedium.copy(
-                                        fontWeight = FontWeight.SemiBold, color = cs.onSurface))
-                            Text(
-                                text = task.date.toString(), // format later if you want
-                                style =
-                                    MaterialTheme.typography.labelSmall.copy(
-                                        color = cs.onSurfaceVariant))
-                          }
-                        }
-                      }
+                      Text(
+                          text = task.title,
+                          style =
+                              MaterialTheme.typography.bodyMedium.copy(
+                                  fontWeight = FontWeight.SemiBold, color = cs.onSurface))
+                      Text(
+                          text = task.date.toString(), // format later if you want
+                          style =
+                              MaterialTheme.typography.labelSmall.copy(color = cs.onSurfaceVariant))
                     }
                   }
                 }
+              }
+            }
           }
-        }
-      }
+    }
+  }
 }

--- a/app/src/main/java/com/android/sample/ui/schedule/MonthTabContent.kt
+++ b/app/src/main/java/com/android/sample/ui/schedule/MonthTabContent.kt
@@ -53,7 +53,7 @@ fun MonthTabContent(
 
   Column(
       modifier = Modifier.fillMaxSize().testTag(MONTH_TAB_CONTENT),
-      verticalArrangement = Arrangement.spacedBy(16.dp),
+      verticalArrangement = Arrangement.spacedBy(Dimensions.spacingLarge),
   ) {
     // ONE AND ONLY big frame — like WeekTabContent
     SectionBox(title = null, header = null) {
@@ -62,13 +62,13 @@ fun MonthTabContent(
       CalendarHeader(
           title = headerTitle, onPrevClick = onPreviousMonthClick, onNextClick = onNextMonthClick)
 
-      Spacer(Modifier.height(8.dp))
+      Spacer(Modifier.height(Dimensions.spacingSmall))
 
       // ───────────── Card with MonthGrid ─────────────
       Card(
           modifier =
               Modifier.fillMaxWidth()
-                  .shadow(8.dp, RoundedCornerShape(24.dp))
+                  .shadow(Dimensions.spacingSmall, RoundedCornerShape(24.dp))
                   .testTag(CalendarScreenTestTags.CALENDAR_CARD),
           colors = CardDefaults.cardColors(containerColor = DarkBlue.copy(alpha = 0.85f)),
           shape = RoundedCornerShape(24.dp)) {
@@ -76,7 +76,9 @@ fun MonthTabContent(
                 modifier =
                     Modifier.fillMaxWidth()
                         .heightIn(min = 260.dp, max = 420.dp)
-                        .padding(horizontal = 8.dp, vertical = 6.dp)) {
+                        .padding(
+                            horizontal = Dimensions.spacingSmall,
+                            vertical = Dimensions.spacingXSmall)) {
                   MonthGrid(
                       currentMonth = currentMonth,
                       selectedDate = selectedDate,
@@ -85,7 +87,7 @@ fun MonthTabContent(
                 }
           }
 
-      Spacer(Modifier.height(16.dp))
+      Spacer(Modifier.height(Dimensions.spacingLarge))
 
       // ───────────── Most important this month (HIGH priority only) ─────────────
       val monthStart = currentMonth.atDay(1)
@@ -116,29 +118,32 @@ fun MonthTabContent(
             } else {
               Column(modifier = Modifier.fillMaxWidth()) {
                 highPriorityMonthTasks.forEach { task ->
-                  Row(modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp)) {
+                  Row(
+                      modifier =
+                          Modifier.fillMaxWidth().padding(vertical = Dimensions.spacingXSmall)) {
 
-                    // small colored bar on the left
-                    Box(
-                        modifier =
-                            Modifier.width(5.dp)
-                                .height(32.dp)
-                                .background(cs.primary, RoundedCornerShape(999.dp)))
+                        // small colored bar on the left
+                        Box(
+                            modifier =
+                                Modifier.width(5.dp)
+                                    .height(32.dp)
+                                    .background(cs.primary, RoundedCornerShape(999.dp)))
 
-                    Spacer(Modifier.width(10.dp))
+                        Spacer(Modifier.width(10.dp))
 
-                    Column(modifier = Modifier.fillMaxWidth()) {
-                      Text(
-                          text = task.title,
-                          style =
-                              MaterialTheme.typography.bodyMedium.copy(
-                                  fontWeight = FontWeight.SemiBold, color = cs.onSurface))
-                      Text(
-                          text = task.date.toString(), // format later if you want
-                          style =
-                              MaterialTheme.typography.labelSmall.copy(color = cs.onSurfaceVariant))
-                    }
-                  }
+                        Column(modifier = Modifier.fillMaxWidth()) {
+                          Text(
+                              text = task.title,
+                              style =
+                                  MaterialTheme.typography.bodyMedium.copy(
+                                      fontWeight = FontWeight.SemiBold, color = cs.onSurface))
+                          Text(
+                              text = task.date.toString(), // format later if you want
+                              style =
+                                  MaterialTheme.typography.labelSmall.copy(
+                                      color = cs.onSurfaceVariant))
+                        }
+                      }
                 }
               }
             }

--- a/app/src/main/java/com/android/sample/ui/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/schedule/ScheduleScreen.kt
@@ -2,6 +2,8 @@ package com.android.sample.ui.schedule
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.*
@@ -34,7 +36,6 @@ import com.android.sample.ui.theme.BackgroundDark
 import com.android.sample.ui.theme.BackgroundGradientEnd
 import com.android.sample.ui.theme.PurplePrimary
 import java.time.LocalDate
-import java.time.YearMonth
 
 /** This class was implemented with the help of ai (ChatGPT) */
 object ScheduleScreenTestTags {
@@ -104,6 +105,7 @@ fun ScheduleScreen(onAddTodoClicked: (LocalDate) -> Unit = {}, onOpenTodo: (Stri
         Column(
             modifier =
                 Modifier.fillMaxSize()
+                    .verticalScroll(rememberScrollState())
                     .padding(padding)
                     .padding(horizontal = 16.dp, vertical = 8.dp)
                     .testTag(ScheduleScreenTestTags.ROOT),
@@ -170,7 +172,7 @@ private fun ScheduleMainContent(
 ) {
   when (currentTab) {
     ScheduleTab.DAY ->
-        Box(Modifier.fillMaxSize().testTag(ScheduleScreenTestTags.CONTENT_DAY)) {
+        Box(Modifier.testTag(ScheduleScreenTestTags.CONTENT_DAY)) {
           DayTabContent(
               vm = vm,
               state = state,
@@ -183,7 +185,7 @@ private fun ScheduleMainContent(
               onTodoClicked = onOpenTodo)
         }
     ScheduleTab.WEEK ->
-        Box(Modifier.fillMaxSize().testTag(ScheduleScreenTestTags.CONTENT_WEEK)) {
+        Box(Modifier.testTag(ScheduleScreenTestTags.CONTENT_WEEK)) {
           WeekTabContent(
               vm = vm,
               objectivesVm = objectivesVm,
@@ -193,11 +195,12 @@ private fun ScheduleMainContent(
               onTodoClicked = onOpenTodo)
         }
     ScheduleTab.MONTH ->
-        Box(Modifier.fillMaxSize().testTag(ScheduleScreenTestTags.CONTENT_MONTH)) {
+        Box(Modifier.testTag(ScheduleScreenTestTags.CONTENT_MONTH)) {
           MonthTabContent(
               allTasks = allTasks,
               selectedDate = state.selectedDate,
-              currentMonth = YearMonth.from(state.selectedDate),
+              // currentMonth = YearMonth.from(state.selectedDate),
+              currentMonth = state.currentDisplayMonth,
               onPreviousMonthClick = { vm.onPreviousMonthWeekClicked() },
               onNextMonthClick = { vm.onNextMonthWeekClicked() },
               onDateSelected = { vm.onDateSelected(it) },

--- a/app/src/main/java/com/android/sample/ui/schedule/WeekTabContent.kt
+++ b/app/src/main/java/com/android/sample/ui/schedule/WeekTabContent.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -61,133 +59,130 @@ fun WeekTabContent(
     onTodoClicked: (String) -> Unit = {}
 ) {
   val weekStart = vm.startOfWeek(selectedDate)
-  LazyColumn(
-      modifier = Modifier.fillMaxSize().testTag("WeekContent"),
-      verticalArrangement = Arrangement.spacedBy(16.dp),
-      contentPadding = PaddingValues(bottom = 96.dp)) {
-        item("week-big-frame") {
-          SectionBox(title = null, header = null) {
-            val weekDays = (0..6).map { weekStart.plusDays(it.toLong()) }
-            val weekTitle =
-                "${weekDays.first().month.name.lowercase().replaceFirstChar { it.uppercase() }} " +
-                    "${weekDays.first().dayOfMonth} - ${weekDays.last().dayOfMonth}"
+  Column(
+      modifier = Modifier.fillMaxSize().padding(bottom = 96.dp).testTag("WeekContent"),
+      verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        SectionBox(title = null, header = null) {
+          val weekDays = (0..6).map { weekStart.plusDays(it.toLong()) }
+          val weekTitle =
+              "${weekDays.first().month.name.lowercase().replaceFirstChar { it.uppercase() }} " +
+                  "${weekDays.first().dayOfMonth} - ${weekDays.last().dayOfMonth}"
 
-            // Header INSIDE the big SectionBox, but OUTSIDE the tiles frame
-            CalendarHeader(
-                title = weekTitle,
-                onPrevClick = { vm.onPreviousMonthWeekClicked() },
-                onNextClick = { vm.onNextMonthWeekClicked() })
-            Spacer(Modifier.height(8.dp))
+          // Header INSIDE the big SectionBox, but OUTSIDE the tiles frame
+          CalendarHeader(
+              title = weekTitle,
+              onPrevClick = { vm.onPreviousMonthWeekClicked() },
+              onNextClick = { vm.onNextMonthWeekClicked() })
+          Spacer(Modifier.height(8.dp))
 
-            // ---- Week header + day tiles (WeekRow renders its own title/arrows) ----
-            Card(
-                modifier =
-                    Modifier.fillMaxWidth()
-                        .shadow(8.dp, RoundedCornerShape(24.dp))
-                        .testTag(CalendarScreenTestTags.CALENDAR_CARD),
-                colors = CardDefaults.cardColors(containerColor = DarkBlue.copy(alpha = 0.85f)),
-                shape = RoundedCornerShape(24.dp)) {
-                  WeekRow(
-                      startOfWeek = weekStart,
-                      selectedDate = selectedDate,
-                      allTasks = allTasks,
-                      onDayClick = { vm.onDateSelected(it) })
-                }
-            Spacer(Modifier.height(16.dp))
+          // ---- Week header + day tiles (WeekRow renders its own title/arrows) ----
+          Card(
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .shadow(8.dp, RoundedCornerShape(24.dp))
+                      .testTag(CalendarScreenTestTags.CALENDAR_CARD),
+              colors = CardDefaults.cardColors(containerColor = DarkBlue.copy(alpha = 0.85f)),
+              shape = RoundedCornerShape(24.dp)) {
+                WeekRow(
+                    startOfWeek = weekStart,
+                    selectedDate = selectedDate,
+                    allTasks = allTasks,
+                    onDayClick = { vm.onDateSelected(it) })
+              }
+          Spacer(Modifier.height(16.dp))
 
-            // ---- Frame: "Week progression" ----
-            SectionBox(
-                header = {
-                  Text(
-                      text = stringResource(R.string.week_progression),
-                      style =
-                          MaterialTheme.typography.titleMedium.copy(
-                              fontSize = 20.sp, fontWeight = FontWeight.Bold, color = Color.White),
-                      modifier = Modifier.padding(bottom = 14.dp))
-                }) {
-                  WeekDotsRow(
-                      objectivesVm,
-                      modifier =
-                          Modifier.fillMaxWidth()
-                              .padding(top = 6.dp)
-                              .testTag(WeekProgDailyObjTags.WEEK_DOTS_ROW))
-                }
+          // ---- Frame: "Week progression" ----
+          SectionBox(
+              header = {
+                Text(
+                    text = stringResource(R.string.week_progression),
+                    style =
+                        MaterialTheme.typography.titleMedium.copy(
+                            fontSize = 20.sp, fontWeight = FontWeight.Bold, color = Color.White),
+                    modifier = Modifier.padding(bottom = 14.dp))
+              }) {
+                WeekDotsRow(
+                    objectivesVm,
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .padding(top = 6.dp)
+                            .testTag(WeekProgDailyObjTags.WEEK_DOTS_ROW))
+              }
 
-            Spacer(Modifier.height(16.dp))
-            SectionBox(
-                header = {
+          Spacer(Modifier.height(16.dp))
+          SectionBox(
+              header = {
+                Text(
+                    text =
+                        stringResource(
+                            R.string.schedule_week_todos_title), // e.g. "This week's To-Dos"
+                    style =
+                        MaterialTheme.typography.titleMedium.copy(
+                            fontSize = 20.sp, fontWeight = FontWeight.Bold, color = Color.White),
+                    modifier = Modifier.padding(bottom = 14.dp))
+              }) {
+                val cs = MaterialTheme.colorScheme
+
+                if (weekTodos.isEmpty()) {
                   Text(
                       text =
                           stringResource(
-                              R.string.schedule_week_todos_title), // e.g. "This week's To-Dos"
-                      style =
-                          MaterialTheme.typography.titleMedium.copy(
-                              fontSize = 20.sp, fontWeight = FontWeight.Bold, color = Color.White),
-                      modifier = Modifier.padding(bottom = 14.dp))
-                }) {
-                  val cs = MaterialTheme.colorScheme
-
-                  if (weekTodos.isEmpty()) {
-                    Text(
-                        text =
-                            stringResource(
-                                R.string.schedule_week_no_todos), // e.g. "No to-dos this week"
-                        color = cs.onSurfaceVariant,
-                        modifier = Modifier.fillMaxWidth())
-                  } else {
-                    Column(modifier = Modifier.fillMaxWidth()) {
-                      val sortedTodos =
-                          remember(weekTodos) {
-                            weekTodos.sortedWith(compareBy({ it.dueDate }, { it.title }))
-                          }
-                      sortedTodos.forEach { todo ->
-                        Row(
-                            modifier =
-                                Modifier.fillMaxWidth().padding(vertical = 6.dp).clickable {
-                                  onTodoClicked(todo.id)
-                                }) {
-                              Box(
-                                  modifier =
-                                      Modifier.width(TodoBarWidth)
-                                          .height(TodoBarHeight)
-                                          .background(cs.primary, RoundedCornerShape(999.dp)))
-                              Spacer(Modifier.width(TodoSpacing))
-                              Column(modifier = Modifier.fillMaxWidth()) {
-                                Text(
-                                    text = todo.title,
-                                    style =
-                                        MaterialTheme.typography.bodyMedium.copy(
-                                            fontWeight = FontWeight.SemiBold, color = cs.onSurface))
-                                Text(
-                                    text = todo.dueDateFormatted(),
-                                    style =
-                                        MaterialTheme.typography.labelSmall.copy(
-                                            color = cs.onSurfaceVariant))
-                              }
+                              R.string.schedule_week_no_todos), // e.g. "No to-dos this week"
+                      color = cs.onSurfaceVariant,
+                      modifier = Modifier.fillMaxWidth())
+                } else {
+                  Column(modifier = Modifier.fillMaxWidth()) {
+                    val sortedTodos =
+                        remember(weekTodos) {
+                          weekTodos.sortedWith(compareBy({ it.dueDate }, { it.title }))
+                        }
+                    sortedTodos.forEach { todo ->
+                      Row(
+                          modifier =
+                              Modifier.fillMaxWidth().padding(vertical = 6.dp).clickable {
+                                onTodoClicked(todo.id)
+                              }) {
+                            Box(
+                                modifier =
+                                    Modifier.width(TodoBarWidth)
+                                        .height(TodoBarHeight)
+                                        .background(cs.primary, RoundedCornerShape(999.dp)))
+                            Spacer(Modifier.width(TodoSpacing))
+                            Column(modifier = Modifier.fillMaxWidth()) {
+                              Text(
+                                  text = todo.title,
+                                  style =
+                                      MaterialTheme.typography.bodyMedium.copy(
+                                          fontWeight = FontWeight.SemiBold, color = cs.onSurface))
+                              Text(
+                                  text = todo.dueDateFormatted(),
+                                  style =
+                                      MaterialTheme.typography.labelSmall.copy(
+                                          color = cs.onSurfaceVariant))
                             }
-                      }
+                          }
                     }
                   }
                 }
+              }
 
-            Spacer(Modifier.height(16.dp))
+          Spacer(Modifier.height(16.dp))
 
-            // ---- Frame: Upcoming events (embedded; no inner GlassSurface) ----
-            SectionBox(title = null) {
-              val end = weekStart.plusDays(6)
-              val from = if (selectedDate.isBefore(weekStart)) weekStart else selectedDate
-              val weekTasks = allTasks.filter { it.date in from..end }
+          // ---- Frame: Upcoming events (embedded; no inner GlassSurface) ----
+          SectionBox(title = null) {
+            val end = weekStart.plusDays(6)
+            val from = if (selectedDate.isBefore(weekStart)) weekStart else selectedDate
+            val weekTasks = allTasks.filter { it.date in from..end }
 
-              UpcomingEventsSection(
-                  tasks =
-                      weekTasks.sortedWith(
-                          compareBy({ it.date }, { it.time ?: java.time.LocalTime.MIN })),
-                  selectedDate = selectedDate,
-                  onAddTaskClick = { /* handled by FAB */ _ -> },
-                  onTaskClick = {},
-                  title = stringResource(R.string.upcoming_events),
-              )
-            }
+            UpcomingEventsSection(
+                tasks =
+                    weekTasks.sortedWith(
+                        compareBy({ it.date }, { it.time ?: java.time.LocalTime.MIN })),
+                selectedDate = selectedDate,
+                onAddTaskClick = { /* handled by FAB */ _ -> },
+                onTaskClick = {},
+                title = stringResource(R.string.upcoming_events),
+            )
           }
         }
       }

--- a/app/src/test/java/com/android/sample/planner/FirestorePlannerRepoUnitTests.kt
+++ b/app/src/test/java/com/android/sample/planner/FirestorePlannerRepoUnitTests.kt
@@ -1,0 +1,111 @@
+package com.android.sample.planner
+
+import com.android.sample.feature.schedule.data.planner.AttendanceStatus
+import com.android.sample.feature.schedule.data.planner.Class
+import com.android.sample.feature.schedule.data.planner.ClassAttendance
+import com.android.sample.feature.schedule.data.planner.ClassType
+import com.android.sample.feature.schedule.data.planner.CompletionStatus
+import com.android.sample.feature.schedule.repository.planner.FirestorePlannerRepository
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDate
+import java.time.LocalTime
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class FirestorePlannerRepositoryUnitTest {
+
+  private lateinit var db: FirebaseFirestore
+  private lateinit var auth: FirebaseAuth
+  private lateinit var repo: FirestorePlannerRepository
+
+  @Before
+  fun setup() {
+    db = mockk(relaxed = true)
+    auth = mockk(relaxed = true)
+    // We create the repo with mocks
+    repo = FirestorePlannerRepository(db, auth)
+  }
+
+  @Test
+  fun `when user is NOT signed in, getTodayClassesFlow delegates to super`() = runBlocking {
+    // Given: No user is logged in
+    every { auth.currentUser } returns null
+
+    // When
+    val classes = repo.getTodayClassesFlow().first()
+
+    // Then: It should return the hardcoded list from PlannerRepository (base class)
+    // The base class usually returns a list containing "Algorithms"
+    assertTrue(classes.isNotEmpty())
+    assertNotNull(classes.find { it.courseName == "Algorithms" })
+  }
+
+  @Test
+  fun `when user is NOT signed in, getTodayAttendanceFlow delegates to super`() = runBlocking {
+    every { auth.currentUser } returns null
+
+    // Save to the *base* repository (in-memory) so we have something to fetch
+    // (Note: FirestorePlannerRepository extends PlannerRepository)
+    val today = LocalDate.now()
+    val att = ClassAttendance("1", today, AttendanceStatus.YES, CompletionStatus.YES)
+    repo.saveAttendance(att)
+
+    val records = repo.getTodayAttendanceFlow().first()
+    assertEquals(1, records.size)
+    assertEquals("1", records[0].classId)
+  }
+
+  @Test
+  fun `when user is NOT signed in, saveAttendance delegates to super`() = runBlocking {
+    every { auth.currentUser } returns null
+
+    val result =
+        repo.saveAttendance(
+            ClassAttendance("99", LocalDate.now(), AttendanceStatus.NO, CompletionStatus.NO))
+
+    assertTrue(result.isSuccess)
+    // Verify it was saved to the in-memory map of the base class
+    val record = repo.getAttendanceForClass("99").first()
+    assertNotNull(record)
+    assertEquals(AttendanceStatus.NO, record?.attendance)
+  }
+
+  @Test
+  fun `when user is NOT signed in, saveClass returns failure`() = runBlocking {
+    every { auth.currentUser } returns null
+    val cls = Class("x", "Test", LocalTime.now(), LocalTime.now(), ClassType.LAB)
+
+    val result = repo.saveClass(cls)
+
+    assertTrue(result.isFailure)
+    assertEquals("Not logged in", result.exceptionOrNull()?.message)
+  }
+
+  @Test
+  fun `when user is NOT signed in, saveClasses returns failure`() = runBlocking {
+    every { auth.currentUser } returns null
+
+    val result = repo.saveClasses(emptyList())
+
+    assertTrue(result.isFailure)
+    assertEquals("Not logged in", result.exceptionOrNull()?.message)
+  }
+
+  @Test
+  fun `when user is NOT signed in, clearClasses returns failure`() = runBlocking {
+    every { auth.currentUser } returns null
+
+    val result = repo.clearClasses()
+
+    assertTrue(result.isFailure)
+    assertEquals("Not logged in", result.exceptionOrNull()?.message)
+  }
+}

--- a/app/src/test/java/com/android/sample/planner/FirestorePlannerRepoUnitTests.kt
+++ b/app/src/test/java/com/android/sample/planner/FirestorePlannerRepoUnitTests.kt
@@ -1,9 +1,7 @@
 package com.android.sample.planner
 
 import com.android.sample.feature.schedule.data.planner.AttendanceStatus
-import com.android.sample.feature.schedule.data.planner.Class
 import com.android.sample.feature.schedule.data.planner.ClassAttendance
-import com.android.sample.feature.schedule.data.planner.ClassType
 import com.android.sample.feature.schedule.data.planner.CompletionStatus
 import com.android.sample.feature.schedule.repository.planner.FirestorePlannerRepository
 import com.google.firebase.auth.FirebaseAuth
@@ -11,7 +9,6 @@ import com.google.firebase.firestore.FirebaseFirestore
 import io.mockk.every
 import io.mockk.mockk
 import java.time.LocalDate
-import java.time.LocalTime
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -81,9 +78,8 @@ class FirestorePlannerRepositoryUnitTest {
   @Test
   fun `when user is NOT signed in, saveClass returns failure`() = runBlocking {
     every { auth.currentUser } returns null
-    val cls = Class("x", "Test", LocalTime.now(), LocalTime.now(), ClassType.LAB)
 
-    val result = repo.saveClass(cls)
+    val result = repo.saveClasses(emptyList())
 
     assertTrue(result.isFailure)
     assertEquals("Not logged in", result.exceptionOrNull()?.message)

--- a/app/src/test/java/com/android/sample/planner/MorePlannerTests.kt
+++ b/app/src/test/java/com/android/sample/planner/MorePlannerTests.kt
@@ -1,0 +1,102 @@
+package com.android.sample.planner
+
+import com.android.sample.feature.schedule.data.planner.AttendanceStatus
+import com.android.sample.feature.schedule.data.planner.Class
+import com.android.sample.feature.schedule.data.planner.ClassAttendance
+import com.android.sample.feature.schedule.data.planner.ClassType
+import com.android.sample.feature.schedule.data.planner.CompletionStatus
+import com.android.sample.feature.schedule.repository.planner.PlannerRepository
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class MorePlannerRepositoryTest {
+
+  private lateinit var repo: PlannerRepository
+
+  @Before
+  fun setup() {
+    repo = PlannerRepository()
+  }
+
+  @Test
+  fun `getTodayClassesFlow emits default hardcoded classes`() = runBlocking {
+    val classes = repo.getTodayClassesFlow().first()
+    assertFalse(classes.isEmpty())
+
+    // Verify one of the default classes exists
+    val algo = classes.find { it.courseName == "Algorithms" }
+    assertNotNull(algo)
+    assertEquals(ClassType.LECTURE, algo?.type)
+  }
+
+  @Test
+  fun `saveAttendance updates internal state and reflects in flows`() = runBlocking {
+    val today = LocalDate.now()
+    val att =
+        ClassAttendance(
+            classId = "1",
+            date = today,
+            attendance = AttendanceStatus.ARRIVED_LATE,
+            completion = CompletionStatus.PARTIALLY,
+            timestamp = Instant.now())
+
+    val result = repo.saveAttendance(att)
+    assertTrue(result.isSuccess)
+
+    // Check getTodayAttendanceFlow
+    val records = repo.getTodayAttendanceFlow().first()
+    val saved = records.find { it.classId == "1" }
+    assertNotNull(saved)
+    assertEquals(AttendanceStatus.ARRIVED_LATE, saved?.attendance)
+
+    // Check getAttendanceForClass
+    val specific = repo.getAttendanceForClass("1").first()
+    assertNotNull(specific)
+    assertEquals(CompletionStatus.PARTIALLY, specific?.completion)
+  }
+
+  @Test
+  fun `saveAttendance overwrites existing record for same day and class`() = runBlocking {
+    val today = LocalDate.now()
+    val att1 = ClassAttendance("1", today, AttendanceStatus.NO, CompletionStatus.NO)
+    val att2 = ClassAttendance("1", today, AttendanceStatus.YES, CompletionStatus.YES)
+
+    repo.saveAttendance(att1)
+    repo.saveAttendance(att2)
+
+    val records = repo.getTodayAttendanceFlow().first()
+    assertEquals(1, records.size)
+    assertEquals(AttendanceStatus.YES, records[0].attendance)
+  }
+
+  @Test
+  fun `seedDemoData populates attendance`() = runBlocking {
+    repo.seedDemoData()
+    val records = repo.getTodayAttendanceFlow().first()
+    assertTrue(records.isNotEmpty())
+    assertEquals("1", records[0].classId)
+  }
+
+  @Test
+  fun `base implementation stubs return expected results`() = runBlocking {
+    // saveClass returns Failure("Not implemented")
+    val dummyClass = Class("id", "Name", LocalTime.now(), LocalTime.now(), ClassType.LECTURE)
+    val saveRes = repo.saveClass(dummyClass)
+    assertTrue(saveRes.isFailure)
+    assertEquals("Not implemented", saveRes.exceptionOrNull()?.message)
+
+    // saveClasses returns Success(Unit)
+    val saveListRes = repo.saveClasses(listOf(dummyClass))
+    assertTrue(saveListRes.isSuccess)
+
+    // clearClasses returns Success(Unit)
+    val clearRes = repo.clearClasses()
+    assertTrue(clearRes.isSuccess)
+  }
+}

--- a/app/src/test/java/com/android/sample/planner/MorePlannerTests.kt
+++ b/app/src/test/java/com/android/sample/planner/MorePlannerTests.kt
@@ -85,13 +85,8 @@ class MorePlannerRepositoryTest {
 
   @Test
   fun `base implementation stubs return expected results`() = runBlocking {
-    // saveClass returns Failure("Not implemented")
-    val dummyClass = Class("id", "Name", LocalTime.now(), LocalTime.now(), ClassType.LECTURE)
-    val saveRes = repo.saveClass(dummyClass)
-    assertTrue(saveRes.isFailure)
-    assertEquals("Not implemented", saveRes.exceptionOrNull()?.message)
-
     // saveClasses returns Success(Unit)
+    val dummyClass = Class("id", "Name", LocalTime.now(), LocalTime.now(), ClassType.LECTURE)
     val saveListRes = repo.saveClasses(listOf(dummyClass))
     assertTrue(saveListRes.isSuccess)
 


### PR DESCRIPTION
## Summary:
This PR addresses several usability and logic issues within the Schedule feature. Specifically, it fixes the screen scrolling behavior to ensure headers scroll with the content, corrects the logic for displaying "Today's Classes" to exclude finished classes and correctly map imported ICS events to their specific days, and restores functionality to the Month View navigation buttons.

## What’s in this PR:

**UI/UX Improvements:**
  -   Refactored ScheduleScreen to make the entire screen scrollable (including the header/pet avatar) rather than having a fixed top section.
  -   Fixed Month View navigation: Previous/Next month buttons now correctly update the currentDisplayMonth state.

**Logic & Data Fixes:**
  - Today's Classes Filtering: Updated the ScheduleViewModel logic to filter out classes that have already ended for the current day (based on endTime < LocalTime.now()).
  - ICS Import Logic: Fixed IcsImporter to correctly derive the DayOfWeek from the event's DTSTART date instead of defaulting to Monday or populating all days. This ensures classes only appear on the specific days they are scheduled.

## Implementation Notes:
- Scrolling: Moved the PetHeader and TabRow composables inside the main scrollable Column in ScheduleScreen.kt.
- Data Consistency (ICS Import): The previous IcsImporter implementation had a fallback that often assigned classes to Monday by default. I updated the parsing logic to extract the exact date from the ICS stream and map it to the correct DayOfWeek in the Class entity.
- Performance: The filtering for "past classes" is done efficiently in the ViewModel's state collection pipeline, ensuring the UI only receives the relevant list of upcoming/current classes.

## Testing:
- Updated past tests to adapt to the new changes.

## Notes:
This PR was implemented with the help of ai (chatgpt).

## Issue Reference:
Closes #243 
