### PR TITLE
Fix(Profile): Fixed the name and e-mail displayed.

### DIFF
--- a/app/src/androidTest/java/com/android/sample/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/android/sample/MainActivityTest.kt
@@ -1,14 +1,22 @@
 package com.android.sample
 
+// This code has been written partially using A.I (LLM).
+
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.sample.profile.ProfileRepositoryProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * Covers MainActivity setContent/theme wiring. No assumptions about specific screens or auth state.
+ * Covers MainActivity setContent/theme wiring and profile sync with Firebase Auth.
+ *
+ * This version does not mock FirebaseUser; it tests the pure data helper instead.
  */
 @RunWith(AndroidJUnit4::class)
 class MainActivityTest {
@@ -18,5 +26,65 @@ class MainActivityTest {
   @Test
   fun launches_and_composition_exists() {
     compose.onRoot().assertExists()
+  }
+
+  @Test
+  fun syncProfileFromAuthData_updates_profile_with_google_data() = runBlocking {
+    val repo = ProfileRepositoryProvider.repository
+    val initialProfile = repo.profile.first()
+
+    compose.activity.syncProfileFromAuthData(
+        displayName = "Google Test User", email = "googletest@gmail.com")
+    compose.waitForIdle()
+
+    val profile = repo.profile.first()
+    assertEquals("Google Test User", profile.name)
+    assertEquals("googletest@gmail.com", profile.email)
+    // Other fields unaffected
+    assertEquals(initialProfile.level, profile.level)
+    assertEquals(initialProfile.points, profile.points)
+  }
+
+  @Test
+  fun syncProfileFromAuthData_handles_null_displayName() = runBlocking {
+    val repo = ProfileRepositoryProvider.repository
+    val initialProfile = repo.profile.first()
+
+    compose.activity.syncProfileFromAuthData(displayName = null, email = "user@gmail.com")
+    compose.waitForIdle()
+
+    val profile = repo.profile.first()
+    // Name falls back to existing profile name
+    assertEquals(initialProfile.name, profile.name)
+    assertEquals("user@gmail.com", profile.email)
+  }
+
+  @Test
+  fun syncProfileFromAuthData_handles_null_email() = runBlocking {
+    val repo = ProfileRepositoryProvider.repository
+    val initialProfile = repo.profile.first()
+
+    compose.activity.syncProfileFromAuthData(displayName = "Test User", email = null)
+    compose.waitForIdle()
+
+    val profile = repo.profile.first()
+    assertEquals("Test User", profile.name)
+    // Email falls back to existing value
+    assertEquals(initialProfile.email, profile.email)
+  }
+
+  @Test
+  fun syncProfileFromAuthData_preserves_other_profile_data() = runBlocking {
+    val repo = ProfileRepositoryProvider.repository
+    val initialProfile = repo.profile.first()
+
+    compose.activity.syncProfileFromAuthData(displayName = "New User Name", email = "new@gmail.com")
+    compose.waitForIdle()
+
+    val updatedProfile = repo.profile.first()
+    assertEquals("New User Name", updatedProfile.name)
+    assertEquals("new@gmail.com", updatedProfile.email)
+    assertEquals(initialProfile.level, updatedProfile.level)
+    assertEquals(initialProfile.points, updatedProfile.points)
   }
 }

--- a/app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTest.kt
@@ -227,6 +227,8 @@ class ProfileScreenTest {
     composeRule.onNodeWithText("0%").assertExists()
   }
 
+  // ========== NEW: ProfileCard Tests with Real Name/Email/Initials ==========
+
   @Test
   fun profileCardDisplaysAllInfo() {
     val user =
@@ -238,8 +240,85 @@ class ProfileScreenTest {
     composeRule.onNodeWithText("john.doe@epfl.ch").assertExists()
     composeRule.onNodeWithText("Level 10").assertExists()
     composeRule.onNodeWithText("500 pts").assertExists()
-    composeRule.onNodeWithText("JO").assertExists() // Initials
+    composeRule.onNodeWithText("JD").assertExists() // Initials
   }
+
+  @Test
+  fun profileCard_displays_correct_initials_for_two_word_name() {
+    val user = UserProfile(name = "Jane Smith", email = "jane@example.com")
+    composeRule.setContent { ProfileCard(user) }
+
+    composeRule.onNodeWithText("JS").assertExists()
+    composeRule.onNodeWithText("Jane Smith").assertExists()
+    composeRule.onNodeWithText("jane@example.com").assertExists()
+  }
+
+  @Test
+  fun profileCard_displays_correct_initials_for_single_name() {
+    val user = UserProfile(name = "Madonna Ariana", email = "madonna@example.com")
+    composeRule.setContent { ProfileCard(user) }
+
+    // Single name should take first 2 letters
+    composeRule.onNodeWithText("MA").assertExists()
+    composeRule.onNodeWithText("Madonna").assertExists()
+  }
+
+  @Test
+  fun profileCard_displays_correct_initials_for_three_word_name() {
+    val user = UserProfile(name = "Mary Jane Watson", email = "mary@example.com")
+    composeRule.setContent { ProfileCard(user) }
+
+    // Should take first letter of first two words
+    composeRule.onNodeWithText("MJ").assertExists()
+    composeRule.onNodeWithText("Mary Jane Watson").assertExists()
+  }
+
+  @Test
+  fun profileCard_handles_lowercase_names() {
+    val user = UserProfile(name = "john smith", email = "john@example.com")
+    composeRule.setContent { ProfileCard(user) }
+
+    // Should uppercase initials
+    composeRule.onNodeWithText("JS").assertExists()
+  }
+
+  @Test
+  fun profileCard_handles_names_with_extra_spaces() {
+    val user = UserProfile(name = "Alice  Bob  Charlie", email = "alice@example.com")
+    composeRule.setContent { ProfileCard(user) }
+
+    // Should handle multiple spaces and take first two words
+    composeRule.onNodeWithText("AB").assertExists()
+  }
+
+  @Test
+  fun profileCard_handles_hyphenated_names() {
+    val user = UserProfile(name = "Jean-Pierre Dubois", email = "jp@example.com")
+    composeRule.setContent { ProfileCard(user) }
+
+    // Should take first letter of each word (hyphenated counts as one word)
+    composeRule.onNodeWithText("JD").assertExists()
+  }
+
+  @Test
+  fun profileCard_handles_empty_name_gracefully() {
+    val user = UserProfile(name = "", email = "user@example.com")
+    composeRule.setContent { ProfileCard(user) }
+
+    // Should display empty name without crashing
+    composeRule.onNodeWithText("user@example.com").assertExists()
+  }
+
+  @Test
+  fun profileCard_displays_google_email_format() {
+    val user = UserProfile(name = "Test User", email = "testuser123@gmail.com")
+    composeRule.setContent { ProfileCard(user) }
+
+    composeRule.onNodeWithText("testuser123@gmail.com").assertExists()
+    composeRule.onNodeWithText("TU").assertExists()
+  }
+
+  // ========== End of New Tests ==========
 
   @Test
   fun statsCardDisplaysAllStats() {

--- a/app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/profile/ProfileScreenTest.kt
@@ -254,16 +254,6 @@ class ProfileScreenTest {
   }
 
   @Test
-  fun profileCard_displays_correct_initials_for_single_name() {
-    val user = UserProfile(name = "Madonna Ariana", email = "madonna@example.com")
-    composeRule.setContent { ProfileCard(user) }
-
-    // Single name should take first 2 letters
-    composeRule.onNodeWithText("MA").assertExists()
-    composeRule.onNodeWithText("Madonna").assertExists()
-  }
-
-  @Test
   fun profileCard_displays_correct_initials_for_three_word_name() {
     val user = UserProfile(name = "Mary Jane Watson", email = "mary@example.com")
     composeRule.setContent { ProfileCard(user) }

--- a/app/src/main/java/com/android/sample/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/ProfileScreen.kt
@@ -279,6 +279,15 @@ fun GlowCard(content: @Composable () -> Unit) {
 
 @Composable
 fun ProfileCard(user: UserProfile) {
+  // Extract initials from the user's name
+  val initials =
+      user.name
+          .split(" ")
+          .filter { it.isNotBlank() }
+          .take(2)
+          .joinToString("") { it.first().uppercase() }
+          .ifEmpty { user.name.take(2).uppercase() }
+
   Column(Modifier.padding(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -287,11 +296,7 @@ fun ProfileCard(user: UserProfile) {
           Box(
               Modifier.size(70.dp).background(AccentViolet, shape = RoundedCornerShape(50.dp)),
               contentAlignment = Alignment.Center) {
-                Text(
-                    user.name.take(2).uppercase(),
-                    color = Color.White,
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 22.sp)
+                Text(initials, color = Color.White, fontWeight = FontWeight.Bold, fontSize = 22.sp)
               }
           Spacer(Modifier.width(20.dp))
           Image(

--- a/app/src/main/java/com/android/sample/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/android/sample/ui/profile/ProfileViewModel.kt
@@ -67,11 +67,9 @@ class ProfileViewModel(
       listOf(
           AccentViolet,
           AccentBlue,
-          AccentMint,
           EventColorSports,
           AccentMagenta,
           PurplePrimary,
-          AccentBlue,
           AccentMint,
           GlowGold,
           VioletSoft)

--- a/app/src/test/java/com/android/sample/ui/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/ui/profile/ProfileViewModelTest.kt
@@ -114,6 +114,84 @@ class ProfileViewModelTest {
     assertTrue(stats.started)
   }
 
+  // ========== NEW: User Profile Name/Email Tests ==========
+
+  @Test
+  fun userProfile_displays_name_from_repository() = runTest {
+    val customProfile = UserProfile(name = "John Doe", email = "john@example.com")
+    val profileRepo = FakeProfileRepository(customProfile)
+    val (vm, _) = vmWith(profileRepo, RecordingUserStatsRepository())
+
+    advanceUntilIdle()
+
+    assertEquals("John Doe", vm.userProfile.value.name)
+  }
+
+  @Test
+  fun userProfile_displays_email_from_repository() = runTest {
+    val customProfile = UserProfile(name = "Jane Smith", email = "jane.smith@gmail.com")
+    val profileRepo = FakeProfileRepository(customProfile)
+    val (vm, _) = vmWith(profileRepo, RecordingUserStatsRepository())
+
+    advanceUntilIdle()
+
+    assertEquals("jane.smith@gmail.com", vm.userProfile.value.email)
+  }
+
+  @Test
+  fun userProfile_handles_single_word_name() = runTest {
+    val customProfile = UserProfile(name = "Madonna", email = "madonna@example.com")
+    val profileRepo = FakeProfileRepository(customProfile)
+    val (vm, _) = vmWith(profileRepo, RecordingUserStatsRepository())
+
+    advanceUntilIdle()
+
+    assertEquals("Madonna", vm.userProfile.value.name)
+    assertEquals("madonna@example.com", vm.userProfile.value.email)
+  }
+
+  @Test
+  fun userProfile_handles_multi_word_name() = runTest {
+    val customProfile = UserProfile(name = "Mary Jane Watson", email = "mary@example.com")
+    val profileRepo = FakeProfileRepository(customProfile)
+    val (vm, _) = vmWith(profileRepo, RecordingUserStatsRepository())
+
+    advanceUntilIdle()
+
+    assertEquals("Mary Jane Watson", vm.userProfile.value.name)
+  }
+
+  @Test
+  fun userProfile_handles_name_with_special_characters() = runTest {
+    val customProfile = UserProfile(name = "Jean-Pierre O'Reilly", email = "jp@example.com")
+    val profileRepo = FakeProfileRepository(customProfile)
+    val (vm, _) = vmWith(profileRepo, RecordingUserStatsRepository())
+
+    advanceUntilIdle()
+
+    assertEquals("Jean-Pierre O'Reilly", vm.userProfile.value.name)
+  }
+
+  @Test
+  fun userProfile_updates_when_repository_changes() = runTest {
+    val initialProfile = UserProfile(name = "Initial User", email = "initial@example.com")
+    val profileRepo = FakeProfileRepository(initialProfile)
+    val (vm, _) = vmWith(profileRepo, RecordingUserStatsRepository())
+
+    advanceUntilIdle()
+    assertEquals("Initial User", vm.userProfile.value.name)
+
+    // Simulate profile update (like after Google sign-in)
+    val updatedProfile = UserProfile(name = "Google User", email = "google@gmail.com")
+    profileRepo.updateProfile(updatedProfile)
+
+    advanceUntilIdle()
+    // Note: The ViewModel copies the profile on init, so this won't auto-update
+    // This test documents current behavior
+  }
+
+  // ========== Existing Tests Continue ==========
+
   @Test
   fun accentPalette_is_not_empty_and_contains_real_colors() = runTest {
     val (vm, _) = vmWith()


### PR DESCRIPTION
## Summary

This PR fixes profile identity inconsistencies and ensures that the user’s real Google information (name, email) is properly synchronized into the app’s profile model. It also removes invalid FirebaseUser mocking, stabilizes profile persistence, and fixes UI issues affecting the Profile screen layout.

## What’s in this PR

- Implemented proper Google Auth → Profile synchronization
- Introduced syncProfileFromAuthData (suspend) and syncProfileWithFirebaseUser (wrapper).
- Updates name/email while preserving stats, level, accessories.
- Replaced placeholder “Alex” with authenticated user initials.
- Ensured avatar uses initials only (no profile picture).
- Profile screen now correctly updates UI once Firestore data is received.

## Implementation Notes

- Syncing occurs in a LaunchedEffect(currentUser.uid) block → avoids redundant writes.
- Profile writes are serialized through updateProfile on the repository.
- Accessories, avatar accent, equipped items remain unchanged and still persist as before.
- The sync helper is kept minimal to avoid schema modifications.
- Tests use direct string-based helper (syncProfileFromAuthData) for stability.

## Testing
**UI / Instrumented:**

- Verified Profile screen renders correctly with real user data.
- Confirmed removal of bottom spacer bar.
- Confirmed initials avatar displays correctly.

## Screenshots / Demos
<img width="312" height="241" alt="image" src="https://github.com/user-attachments/assets/de936f5d-d802-4d94-bba3-86bd214bfc21" />


## Checklist
- [x] The edumon stats should be the same as the profile screen
- [x] Everything is coherent and persistent (stats, name, e-mail)


## Notes
Parts of the code inside this PR and parts of this PR have been written using the help of an LLM.
## Issue Reference
Closes #192 

