### PR TITLE
feature(schedule): Adapt dailyObjectives to daily courses

### DIFF
--- a/app/src/main/java/com/android/sample/feature/schedule/usecase/DailyClassObjectiveGenerator.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/usecase/DailyClassObjectiveGenerator.kt
@@ -20,22 +20,24 @@ class DailyClassObjectiveGenerator {
   ): List<Objective> {
     return todayClasses.mapNotNull { clazz ->
       when (clazz.type) {
-        ClassType.LECTURE -> createLectureObjective(clazz, day)
+        ClassType.LECTURE -> createLectureObjective(clazz, currentWeek, day)
         ClassType.EXERCISE -> createExerciseObjective(clazz, currentWeek, day)
         ClassType.LAB -> createLabObjective(clazz, currentWeek, day)
-        ClassType.PROJECT -> createProjectObjective(clazz, day)
+        ClassType.PROJECT -> createProjectObjective(clazz, currentWeek, day)
       }
     }
   }
 
-  private fun createLectureObjective(clazz: Class, day: DayOfWeek): Objective {
+  private fun createLectureObjective(clazz: Class, week: Int, day: DayOfWeek): Objective {
     return Objective(
         title = "Review ${clazz.courseName} lecture",
         course = clazz.courseName,
         estimateMinutes = 45,
         completed = false,
         day = day,
-        type = ObjectiveType.COURSE_OR_EXERCISES)
+        type = ObjectiveType.COURSE_OR_EXERCISES,
+        isAuto = true,
+        sourceId = "AUTO:${clazz.courseName}:${clazz.type}:$week")
   }
 
   private fun createExerciseObjective(clazz: Class, week: Int, day: DayOfWeek): Objective {
@@ -45,7 +47,9 @@ class DailyClassObjectiveGenerator {
         estimateMinutes = 60,
         completed = false,
         day = day,
-        type = ObjectiveType.COURSE_OR_EXERCISES)
+        type = ObjectiveType.COURSE_OR_EXERCISES,
+        isAuto = true,
+        sourceId = "AUTO:${clazz.courseName}:${clazz.type}:$week")
   }
 
   private fun createLabObjective(clazz: Class, week: Int, day: DayOfWeek): Objective {
@@ -55,16 +59,20 @@ class DailyClassObjectiveGenerator {
         estimateMinutes = 90,
         completed = false,
         day = day,
-        type = ObjectiveType.COURSE_OR_EXERCISES)
+        type = ObjectiveType.COURSE_OR_EXERCISES,
+        isAuto = true,
+        sourceId = "AUTO:${clazz.courseName}:${clazz.type}:$week")
   }
 
-  private fun createProjectObjective(clazz: Class, day: DayOfWeek): Objective {
+  private fun createProjectObjective(clazz: Class, week: Int, day: DayOfWeek): Objective {
     return Objective(
         title = "Work on ${clazz.courseName} project",
         course = clazz.courseName,
         estimateMinutes = 60,
         completed = false,
         day = day,
-        type = ObjectiveType.COURSE_OR_EXERCISES)
+        type = ObjectiveType.COURSE_OR_EXERCISES,
+        isAuto = true,
+        sourceId = "AUTO:${clazz.courseName}:${clazz.type}:$week")
   }
 }

--- a/app/src/main/java/com/android/sample/feature/schedule/usecase/DailyClassObjectiveGenerator.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/usecase/DailyClassObjectiveGenerator.kt
@@ -11,6 +11,11 @@ import java.time.LocalDate
  * Generates daily learning objectives from today's planner classes. Pure domain logic – no Android,
  * no Firestore, no UI dependencies.
  */
+private const val LECTURE_REVIEW_MINUTES = 45
+private const val EXERCISE_SET_MINUTES = 60
+private const val LAB_PREPARATION_MINUTES = 90
+private const val PROJECT_WORK_MINUTES = 60
+
 class DailyClassObjectiveGenerator {
 
   fun generate(
@@ -32,7 +37,7 @@ class DailyClassObjectiveGenerator {
     return Objective(
         title = "Review ${clazz.courseName} lecture",
         course = clazz.courseName,
-        estimateMinutes = 45,
+        estimateMinutes = LECTURE_REVIEW_MINUTES,
         completed = false,
         day = day,
         type = ObjectiveType.COURSE_OR_EXERCISES,
@@ -44,7 +49,7 @@ class DailyClassObjectiveGenerator {
     return Objective(
         title = "Do ${clazz.courseName} exercise set $week",
         course = clazz.courseName,
-        estimateMinutes = 60,
+        estimateMinutes = EXERCISE_SET_MINUTES,
         completed = false,
         day = day,
         type = ObjectiveType.COURSE_OR_EXERCISES,
@@ -56,7 +61,7 @@ class DailyClassObjectiveGenerator {
     return Objective(
         title = "Prepare ${clazz.courseName} lab (week $week)",
         course = clazz.courseName,
-        estimateMinutes = 90,
+        estimateMinutes = LAB_PREPARATION_MINUTES,
         completed = false,
         day = day,
         type = ObjectiveType.COURSE_OR_EXERCISES,
@@ -68,7 +73,7 @@ class DailyClassObjectiveGenerator {
     return Objective(
         title = "Work on ${clazz.courseName} project",
         course = clazz.courseName,
-        estimateMinutes = 60,
+        estimateMinutes = PROJECT_WORK_MINUTES,
         completed = false,
         day = day,
         type = ObjectiveType.COURSE_OR_EXERCISES,

--- a/app/src/main/java/com/android/sample/feature/schedule/usecase/DailyClassObjectiveGenerator.kt
+++ b/app/src/main/java/com/android/sample/feature/schedule/usecase/DailyClassObjectiveGenerator.kt
@@ -1,0 +1,70 @@
+package com.android.sample.feature.schedule.usecase
+
+import com.android.sample.feature.schedule.data.planner.Class
+import com.android.sample.feature.schedule.data.planner.ClassType
+import com.android.sample.feature.weeks.model.Objective
+import com.android.sample.feature.weeks.model.ObjectiveType
+import java.time.DayOfWeek
+import java.time.LocalDate
+
+/**
+ * Generates daily learning objectives from today's planner classes. Pure domain logic – no Android,
+ * no Firestore, no UI dependencies.
+ */
+class DailyClassObjectiveGenerator {
+
+  fun generate(
+      todayClasses: List<Class>,
+      currentWeek: Int,
+      day: DayOfWeek = LocalDate.now().dayOfWeek
+  ): List<Objective> {
+    return todayClasses.mapNotNull { clazz ->
+      when (clazz.type) {
+        ClassType.LECTURE -> createLectureObjective(clazz, day)
+        ClassType.EXERCISE -> createExerciseObjective(clazz, currentWeek, day)
+        ClassType.LAB -> createLabObjective(clazz, currentWeek, day)
+        ClassType.PROJECT -> createProjectObjective(clazz, day)
+      }
+    }
+  }
+
+  private fun createLectureObjective(clazz: Class, day: DayOfWeek): Objective {
+    return Objective(
+        title = "Review ${clazz.courseName} lecture",
+        course = clazz.courseName,
+        estimateMinutes = 45,
+        completed = false,
+        day = day,
+        type = ObjectiveType.COURSE_OR_EXERCISES)
+  }
+
+  private fun createExerciseObjective(clazz: Class, week: Int, day: DayOfWeek): Objective {
+    return Objective(
+        title = "Do ${clazz.courseName} exercise set $week",
+        course = clazz.courseName,
+        estimateMinutes = 60,
+        completed = false,
+        day = day,
+        type = ObjectiveType.COURSE_OR_EXERCISES)
+  }
+
+  private fun createLabObjective(clazz: Class, week: Int, day: DayOfWeek): Objective {
+    return Objective(
+        title = "Prepare ${clazz.courseName} lab (week $week)",
+        course = clazz.courseName,
+        estimateMinutes = 90,
+        completed = false,
+        day = day,
+        type = ObjectiveType.COURSE_OR_EXERCISES)
+  }
+
+  private fun createProjectObjective(clazz: Class, day: DayOfWeek): Objective {
+    return Objective(
+        title = "Work on ${clazz.courseName} project",
+        course = clazz.courseName,
+        estimateMinutes = 60,
+        completed = false,
+        day = day,
+        type = ObjectiveType.COURSE_OR_EXERCISES)
+  }
+}

--- a/app/src/main/java/com/android/sample/feature/weeks/model/Objective.kt
+++ b/app/src/main/java/com/android/sample/feature/weeks/model/Objective.kt
@@ -22,5 +22,7 @@ data class Objective(
     val day: DayOfWeek,
     val type: ObjectiveType = ObjectiveType.COURSE_OR_EXERCISES,
     val coursePdfUrl: String = DEFAULT_COURSE_PDF_URL,
-    val exercisePdfUrl: String = DEFAULT_EXERCISE_PDF_URL
+    val exercisePdfUrl: String = DEFAULT_EXERCISE_PDF_URL,
+    val isAuto: Boolean = false,
+    val sourceId: String? = null
 )

--- a/app/src/main/java/com/android/sample/feature/weeks/repository/FirestoreObjectivesRepository.kt
+++ b/app/src/main/java/com/android/sample/feature/weeks/repository/FirestoreObjectivesRepository.kt
@@ -40,6 +40,8 @@ class FirestoreObjectivesRepository(
           "exercisePdfUrl" to exercisePdfUrl,
           "order" to (order ?: 0L),
           "updatedAt" to FieldValue.serverTimestamp(),
+          "isAuto" to isAuto,
+          "sourceId" to sourceId,
       )
 
   private fun DocumentSnapshot.toDomain(): Objective {
@@ -49,6 +51,8 @@ class FirestoreObjectivesRepository(
     val completed = getBoolean("completed") ?: false
     val dayStr = getString("day") ?: DayOfWeek.MONDAY.name
     val dow = runCatching { DayOfWeek.valueOf(dayStr) }.getOrElse { DayOfWeek.MONDAY }
+    val isAuto = getBoolean("isAuto") ?: false
+    val sourceId = getString("sourceId")
 
     // Safely read the type; default to COURSE_OR_EXERCISES for old documents
     val typeStr = getString("type") ?: ObjectiveType.COURSE_OR_EXERCISES.name
@@ -68,7 +72,9 @@ class FirestoreObjectivesRepository(
         day = dow,
         type = type,
         coursePdfUrl = coursePdfUrl,
-        exercisePdfUrl = exercisePdfUrl)
+        exercisePdfUrl = exercisePdfUrl,
+        isAuto = isAuto,
+        sourceId = sourceId)
   }
 
   private suspend fun fetchOrdered(): MutableList<Pair<DocumentSnapshot, Objective>> =

--- a/app/src/main/java/com/android/sample/feature/weeks/ui/DailyObjectivesSection.kt
+++ b/app/src/main/java/com/android/sample/feature/weeks/ui/DailyObjectivesSection.kt
@@ -103,7 +103,7 @@ fun DailyObjectivesSection(
           index = firstObjIndex.coerceAtLeast(0),
           objective = todayObjectives.first(),
           showWhy = showWhy) {
-            viewModel.startObjective(firstObjIndex.coerceAtLeast(0))
+            viewModel.startObjective(todayObjectives.first())
           }
 
       val remaining = todayObjectives.drop(1)
@@ -121,7 +121,7 @@ fun DailyObjectivesSection(
                   val actualIndex = ui.objectives.indexOf(obj)
                   ObjectiveRow(
                       index = actualIndex.coerceAtLeast(0), objective = obj, showWhy = showWhy) {
-                        viewModel.startObjective(actualIndex.coerceAtLeast(0))
+                        viewModel.startObjective(obj)
                       }
                 }
               }
@@ -148,12 +148,12 @@ private fun ObjectiveRow(index: Int, objective: Objective, showWhy: Boolean, onS
   val cs = MaterialTheme.colorScheme
   Column(Modifier.fillMaxWidth().testTag(WeekProgDailyObjTags.OBJECTIVE_ROW_PREFIX + index)) {
     Text(
-        objective.title,
+        text = objective.title,
         style =
             MaterialTheme.typography.titleLarge.copy(
                 color = cs.onSurface, fontWeight = FontWeight.Bold),
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
+        maxLines = Int.MAX_VALUE,
+        overflow = TextOverflow.Visible,
         modifier =
             Modifier.padding(bottom = 6.dp)
                 .testTag(WeekProgDailyObjTags.OBJECTIVE_TITLE_PREFIX + index))

--- a/app/src/main/java/com/android/sample/feature/weeks/viewmodel/ObjectivesViewModel.kt
+++ b/app/src/main/java/com/android/sample/feature/weeks/viewmodel/ObjectivesViewModel.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
@@ -53,11 +53,22 @@ class ObjectivesViewModel(
   private val _uiState = MutableStateFlow(ObjectivesUiState())
   val uiState = _uiState.asStateFlow()
 
+  /*val todayObjectives =
+  _uiState.map { state ->
+    val today = LocalDate.now().dayOfWeek
+    state.objectives.filter { it.day == today }
+  }*/
+  private val _autoObjectives = MutableStateFlow<List<Objective>>(emptyList())
+
   val todayObjectives =
-      _uiState.map { state ->
+      combine(_uiState, _autoObjectives) { state, auto ->
         val today = LocalDate.now().dayOfWeek
-        state.objectives.filter { it.day == today }
+        (state.objectives + auto).filter { it.day == today }
       }
+
+  fun replaceAutoObjectives(objs: List<Objective>) {
+    _autoObjectives.value = objs
+  }
 
   private val _navigationEvents = MutableSharedFlow<ObjectiveNavigation>()
   val navigationEvents = _navigationEvents.asSharedFlow()

--- a/app/src/main/java/com/android/sample/feature/weeks/viewmodel/ObjectivesViewModel.kt
+++ b/app/src/main/java/com/android/sample/feature/weeks/viewmodel/ObjectivesViewModel.kt
@@ -51,12 +51,6 @@ class ObjectivesViewModel(
 
   private val _uiState = MutableStateFlow(ObjectivesUiState())
   val uiState = _uiState.asStateFlow()
-
-  /*val todayObjectives =
-  _uiState.map { state ->
-    val today = LocalDate.now().dayOfWeek
-    state.objectives.filter { it.day == today }
-  }*/
   private val _autoObjectives = MutableStateFlow<List<Objective>>(emptyList())
 
   val todayObjectives =

--- a/app/src/main/java/com/android/sample/ui/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/schedule/ScheduleScreen.kt
@@ -94,6 +94,10 @@ fun ScheduleScreen(
   val objectivesVm: ObjectivesViewModel = viewModel()
   val state by vm.uiState.collectAsState()
 
+  LaunchedEffect(state.generatedObjectives) {
+    objectivesVm.replaceAutoObjectives(state.generatedObjectives)
+  }
+
   var currentTab by remember { mutableStateOf(ScheduleTab.DAY) }
   var activeObjective by remember { mutableStateOf<Objective?>(null) }
 

--- a/app/src/test/java/com/android/sample/ui/schedule/ObjectivesGeneratorTest.kt
+++ b/app/src/test/java/com/android/sample/ui/schedule/ObjectivesGeneratorTest.kt
@@ -1,0 +1,106 @@
+package com.android.sample.ui.schedule
+
+import com.android.sample.feature.schedule.data.planner.Class
+import com.android.sample.feature.schedule.data.planner.ClassType
+import com.android.sample.feature.schedule.usecase.DailyClassObjectiveGenerator
+import com.android.sample.feature.weeks.model.ObjectiveType
+import java.time.DayOfWeek
+import java.time.LocalTime
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DailyClassObjectiveGeneratorTest {
+
+  private val generator = DailyClassObjectiveGenerator()
+
+  private fun baseClass(name: String, type: ClassType): Class =
+      Class(
+          courseName = name,
+          startTime = LocalTime.of(8, 0),
+          endTime = LocalTime.of(10, 0),
+          type = type)
+
+  @Test
+  fun `generate creates lecture objective correctly`() {
+    val clazz = baseClass("CompSec", ClassType.LECTURE)
+
+    val result =
+        generator.generate(todayClasses = listOf(clazz), currentWeek = 12, day = DayOfWeek.MONDAY)
+
+    val obj = result.single()
+
+    assertEquals("Review CompSec lecture", obj.title)
+    assertEquals("CompSec", obj.course)
+    assertEquals(45, obj.estimateMinutes)
+    assertEquals(DayOfWeek.MONDAY, obj.day)
+    assertEquals(ObjectiveType.COURSE_OR_EXERCISES, obj.type)
+    assertTrue(obj.isAuto)
+    assertFalse(obj.completed)
+    assertEquals("AUTO:CompSec:LECTURE:12", obj.sourceId)
+  }
+
+  @Test
+  fun `generate creates exercise objective correctly`() {
+    val clazz = baseClass("Math", ClassType.EXERCISE)
+
+    val result =
+        generator.generate(todayClasses = listOf(clazz), currentWeek = 5, day = DayOfWeek.TUESDAY)
+
+    val obj = result.single()
+
+    assertEquals("Do Math exercise set 5", obj.title)
+    assertEquals(60, obj.estimateMinutes)
+    assertEquals("AUTO:Math:EXERCISE:5", obj.sourceId)
+  }
+
+  @Test
+  fun `generate creates lab objective correctly`() {
+    val clazz = baseClass("Networks", ClassType.LAB)
+
+    val result =
+        generator.generate(todayClasses = listOf(clazz), currentWeek = 3, day = DayOfWeek.WEDNESDAY)
+
+    val obj = result.single()
+
+    assertEquals("Prepare Networks lab (week 3)", obj.title)
+    assertEquals(90, obj.estimateMinutes)
+    assertEquals("AUTO:Networks:LAB:3", obj.sourceId)
+  }
+
+  @Test
+  fun `generate creates project objective correctly`() {
+    val clazz = baseClass("AI", ClassType.PROJECT)
+
+    val result =
+        generator.generate(todayClasses = listOf(clazz), currentWeek = 7, day = DayOfWeek.THURSDAY)
+
+    val obj = result.single()
+
+    assertEquals("Work on AI project", obj.title)
+    assertEquals(60, obj.estimateMinutes)
+    assertEquals("AUTO:AI:PROJECT:7", obj.sourceId)
+  }
+
+  @Test
+  fun `generate supports multiple classes and preserves order`() {
+    val classes = listOf(baseClass("OS", ClassType.LECTURE), baseClass("OS", ClassType.EXERCISE))
+
+    val result =
+        generator.generate(todayClasses = classes, currentWeek = 10, day = DayOfWeek.FRIDAY)
+
+    assertEquals(2, result.size)
+    assertEquals("Review OS lecture", result[0].title)
+    assertEquals("Do OS exercise set 10", result[1].title)
+  }
+
+  @Test
+  fun `generate uses default day when not provided`() {
+    val clazz = baseClass("DB", ClassType.LECTURE)
+
+    val result = generator.generate(todayClasses = listOf(clazz), currentWeek = 1)
+
+    assertEquals(java.time.LocalDate.now().dayOfWeek, result.single().day)
+  }
+}


### PR DESCRIPTION
## Summary:

Generate daily learning objectives dynamically from the user’s schedule and remove static demo objectives. Objectives now behave consistently (navigation, completion, rewards) and remain stable across app restarts.

## What’s in this PR:

- Generate daily objectives from planner classes (lecture, exercise, lab, project)
- Remove hardcoded/default objectives
- Enable Start → navigation → completion for generated objectives
- Deduplicate objectives using a stable sourceId
- Persist completed auto objectives only

Increase unit test coverage to ≥95%

## Schema changes:
Firestore Objectives: add sourceId and isAuto

## Implementation Notes:
- Auto objectives are suggestions; they are stored only when completed
- Deduplication is based on persisted objectives to survive app restarts
- Object-based navigation replaces index-based logic

## Testing:

- Unit: DailyClassObjectiveGenerator, ObjectivesViewModel (all branches)
- UI: daily objectives flow, navigation, completion state

## Notes:
This PR was implemented with the the help of ia (chatgbt).

## Issue Reference:
Closes #267 
